### PR TITLE
refactor: split project store into slices

### DIFF
--- a/src/store/checklistStore.ts
+++ b/src/store/checklistStore.ts
@@ -1,0 +1,88 @@
+import type { StateCreator } from 'zustand';
+import { ChecklistItem } from '../types';
+import type { ProjectState } from './useProjectStore';
+import { findProject, updateProjectInFirestore } from './projectHelpers';
+
+export interface ChecklistSlice {
+  addChecklistItem: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    text: string
+  ) => Promise<void>;
+  deleteChecklistItem: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    itemId: string
+  ) => Promise<void>;
+  toggleChecklistItemHidden: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    itemId: string,
+    isHidden: boolean
+  ) => Promise<void>;
+  reorderChecklistItems: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    sourceIndex: number,
+    destinationIndex: number
+  ) => Promise<void>;
+}
+
+export const createChecklistSlice: StateCreator<ProjectState, [], [], ChecklistSlice> = (set, get) => ({
+  addChecklistItem: async (projectId, phase, text) => {
+    const project = findProject(get, projectId);
+    const newItem: ChecklistItem = {
+      id: `${phase}-${Date.now()}`,
+      text,
+      checked: false,
+      isDefault: false,
+      isHidden: false,
+    };
+    const updatedChecklist = [...project.data[phase].checklist, newItem];
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...project.data[phase], checklist: updatedChecklist } },
+      get,
+      set
+    );
+  },
+
+  deleteChecklistItem: async (projectId, phase, itemId) => {
+    const project = findProject(get, projectId);
+    const updatedChecklist = project.data[phase].checklist.filter(
+      (item) => !(item.id === itemId && !item.isDefault)
+    );
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...project.data[phase], checklist: updatedChecklist } },
+      get,
+      set
+    );
+  },
+
+  toggleChecklistItemHidden: async (projectId, phase, itemId, isHidden) => {
+    const project = findProject(get, projectId);
+    const updatedChecklist = project.data[phase].checklist.map((item) =>
+      item.id === itemId ? { ...item, isHidden } : item
+    );
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...project.data[phase], checklist: updatedChecklist } },
+      get,
+      set
+    );
+  },
+
+  reorderChecklistItems: async (projectId, phase, sourceIndex, destinationIndex) => {
+    const project = findProject(get, projectId);
+    const checklist = [...project.data[phase].checklist];
+    const [reorderedItem] = checklist.splice(sourceIndex, 1);
+    checklist.splice(destinationIndex, 0, reorderedItem);
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...project.data[phase], checklist } },
+      get,
+      set
+    );
+  },
+});

--- a/src/store/projectHelpers.ts
+++ b/src/store/projectHelpers.ts
@@ -1,0 +1,38 @@
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import { Project, ProjectData } from '../types';
+
+export type GetState = () => { projects: Project[]; currentProject: Project | null };
+export type SetState = (state: Partial<{ projects: Project[]; currentProject: Project | null }>) => void;
+
+export const findProject = (get: GetState, id: string): Project => {
+  const project = get().projects.find(p => p.id === id);
+  if (!project) {
+    throw new Error('Projet non trouvé');
+  }
+  return project;
+};
+
+export const calculateCurrentPhase = (data: ProjectData): 'initial' | 'options' | 'final' => {
+  if (!data.initial.validated) return 'initial';
+  if (!data.options.validated) return 'options';
+  return 'final';
+};
+
+export const updateProjectInFirestore = async (
+  id: string,
+  updates: Partial<ProjectData>,
+  get: GetState,
+  set: SetState
+): Promise<void> => {
+  const projectRef = doc(db, 'projects', id);
+  const currentProject = findProject(get, id);
+  const updatedData = { ...currentProject.data, ...updates };
+  const currentPhase = calculateCurrentPhase(updatedData);
+
+  await updateDoc(projectRef, { data: updatedData, currentPhase });
+
+  if (get().currentProject?.id === id) {
+    set({ currentProject: { ...get().currentProject!, data: updatedData, currentPhase } });
+  }
+};

--- a/src/store/scenarioStore.ts
+++ b/src/store/scenarioStore.ts
@@ -1,0 +1,54 @@
+import type { StateCreator } from 'zustand';
+import type { ProjectState } from './useProjectStore';
+import { findProject, updateProjectInFirestore } from './projectHelpers';
+
+export interface ScenarioSlice {
+  updateScenarioSectionContent: (
+    projectId: string,
+    scenarioId: 'A' | 'B',
+    sectionId: string,
+    updates: { content?: string; internalOnly?: boolean }
+  ) => Promise<void>;
+  updateOptionsSelectedScenario: (
+    projectId: string,
+    scenarioId: string
+  ) => Promise<void>;
+}
+
+export const createScenarioSlice: StateCreator<ProjectState, [], [], ScenarioSlice> = (set, get) => ({
+  updateScenarioSectionContent: async (projectId, scenarioId, sectionId, updates) => {
+    const project = findProject(get, projectId);
+    const currentContent =
+      project.data.options.scenarios[scenarioId]?.sectionContents[sectionId] || {
+        content: '',
+        internalOnly: false,
+      };
+    const updatedContent = { ...currentContent, ...updates };
+    const updatedScenarios = {
+      ...project.data.options.scenarios,
+      [scenarioId]: {
+        ...project.data.options.scenarios[scenarioId],
+        sectionContents: {
+          ...project.data.options.scenarios[scenarioId]?.sectionContents,
+          [sectionId]: updatedContent,
+        },
+      },
+    };
+    await updateProjectInFirestore(
+      projectId,
+      { options: { ...project.data.options, scenarios: updatedScenarios } },
+      get,
+      set
+    );
+  },
+
+  updateOptionsSelectedScenario: async (projectId, scenarioId) => {
+    const project = findProject(get, projectId);
+    await updateProjectInFirestore(
+      projectId,
+      { options: { ...project.data.options, selectedScenarioId: scenarioId } },
+      get,
+      set
+    );
+  },
+});

--- a/src/store/sectionStore.ts
+++ b/src/store/sectionStore.ts
@@ -1,0 +1,137 @@
+import type { StateCreator } from 'zustand';
+import { ProjectSection } from '../types';
+import type { ProjectState } from './useProjectStore';
+import { findProject, updateProjectInFirestore } from './projectHelpers';
+
+export interface SectionSlice {
+  addProjectSection: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    newSection: Omit<ProjectSection, 'id' | 'order'>
+  ) => Promise<void>;
+  updateProjectSection: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    sectionId: string,
+    updates: Partial<ProjectSection>
+  ) => Promise<void>;
+  deleteProjectSection: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    sectionId: string
+  ) => Promise<void>;
+  toggleProjectSectionHidden: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    sectionId: string,
+    isHidden: boolean
+  ) => Promise<void>;
+  reorderProjectSections: (
+    projectId: string,
+    phase: 'initial' | 'options' | 'final',
+    sourceIndex: number,
+    destinationIndex: number
+  ) => Promise<void>;
+}
+
+export const createSectionSlice: StateCreator<ProjectState, [], [], SectionSlice> = (set, get) => ({
+  addProjectSection: async (projectId, phase, newSection) => {
+    const project = findProject(get, projectId);
+    const phaseData = project.data[phase] as any;
+    const sections = phaseData.sections as ProjectSection[];
+    const maxOrder = sections.length > 0 ? Math.max(...sections.map((s) => s.order)) : -1;
+    const newProjectSection: ProjectSection = {
+      id: `${phase}-section-${Date.now()}`,
+      order: maxOrder + 1,
+      ...newSection,
+    };
+    const updatedSections = [...sections, newProjectSection];
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...phaseData, sections: updatedSections } },
+      get,
+      set
+    );
+  },
+
+  updateProjectSection: async (projectId, phase, sectionId, updates) => {
+    const project = findProject(get, projectId);
+    const phaseData = project.data[phase] as any;
+    const updatedSections = phaseData.sections.map((section: ProjectSection) =>
+      section.id === sectionId ? { ...section, ...updates } : section
+    );
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...phaseData, sections: updatedSections } },
+      get,
+      set
+    );
+  },
+
+  deleteProjectSection: async (projectId, phase, sectionId) => {
+    const project = findProject(get, projectId);
+    const phaseData = project.data[phase] as any;
+    const updatedSections = phaseData.sections.filter(
+      (section: ProjectSection) => !(section.id === sectionId && !section.isDefault)
+    );
+    if (phase === 'options') {
+      const scenarios = project.data.options.scenarios;
+      const updatedScenarios = {
+        A: {
+          ...scenarios.A,
+          sectionContents: Object.fromEntries(
+            Object.entries(scenarios.A.sectionContents).filter(([id]) => id !== sectionId)
+          ),
+        },
+        B: {
+          ...scenarios.B,
+          sectionContents: Object.fromEntries(
+            Object.entries(scenarios.B.sectionContents).filter(([id]) => id !== sectionId)
+          ),
+        },
+      };
+      await updateProjectInFirestore(
+        projectId,
+        { [phase]: { ...phaseData, sections: updatedSections, scenarios: updatedScenarios } },
+        get,
+        set
+      );
+    } else {
+      await updateProjectInFirestore(
+        projectId,
+        { [phase]: { ...phaseData, sections: updatedSections } },
+        get,
+        set
+      );
+    }
+  },
+
+  toggleProjectSectionHidden: async (projectId, phase, sectionId, isHidden) => {
+    const project = findProject(get, projectId);
+    const phaseData = project.data[phase] as any;
+    const updatedSections = phaseData.sections.map((section: ProjectSection) =>
+      section.id === sectionId ? { ...section, isHidden } : section
+    );
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...phaseData, sections: updatedSections } },
+      get,
+      set
+    );
+  },
+
+  reorderProjectSections: async (projectId, phase, sourceIndex, destinationIndex) => {
+    const project = findProject(get, projectId);
+    const phaseData = project.data[phase] as any;
+    const sections = [...(phaseData.sections as ProjectSection[])];
+    const [reorderedSection] = sections.splice(sourceIndex, 1);
+    sections.splice(destinationIndex, 0, reorderedSection);
+    const updatedSections = sections.map((section, index) => ({ ...section, order: index }));
+    await updateProjectInFirestore(
+      projectId,
+      { [phase]: { ...phaseData, sections: updatedSections } },
+      get,
+      set
+    );
+  },
+});


### PR DESCRIPTION
## Summary
- split project store logic into checklist, section, and scenario slices
- centralize project lookup and firestore updates in reusable helpers
- update main project store to compose slices and use helpers

## Testing
- `npm run lint` *(fails: ESLint configuration missing)*
- `npx tsc --noEmit` *(fails: 158 TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e279ce8c8327914697aa7f8dd056