### PR TITLE
feat: renforcer la gestion d'authentification

### DIFF
--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
-import { signInWithEmailAndPassword, signOut, onAuthStateChanged, User as FirebaseUser } from 'firebase/auth';
+import {
+  signInWithEmailAndPassword,
+  signOut,
+  onAuthStateChanged,
+  User as FirebaseUser,
+} from 'firebase/auth';
 import { auth } from '../firebase';
 import { User } from '../types';
 
@@ -7,66 +12,74 @@ interface AuthState {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+}
+
+interface AuthActions {
   login: (email: string, password: string) => Promise<boolean>;
   logout: () => Promise<void>;
   setUser: (user: User | null) => void;
   setLoading: (loading: boolean) => void;
 }
 
-export const useAuthStore = create<AuthState>((set, get) => ({
+export const useAuthStore = create<AuthState & AuthActions>((set) => ({
   user: null,
   isAuthenticated: false,
   isLoading: true,
-  
-  login: async (email: string, password: string) => {
+
+  login: async (email, password) => {
     try {
-      const userCredential = await signInWithEmailAndPassword(auth, email, password);
-      const firebaseUser = userCredential.user;
-      
+      const { user: firebaseUser } = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password,
+      );
+
+      if (!firebaseUser) {
+        throw new Error('Aucun utilisateur retourné après authentification');
+      }
+
       const user: User = {
         id: firebaseUser.uid,
-        username: firebaseUser.email || 'Utilisateur'
+        username: firebaseUser.email ?? 'Utilisateur',
       };
-      
+
       set({ user, isAuthenticated: true });
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Erreur de connexion:', error);
       throw error;
     }
   },
-  
+
   logout: async () => {
     try {
       await signOut(auth);
-      set({ user: null, isAuthenticated: false });
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Erreur de déconnexion:', error);
+    } finally {
+      set({ user: null, isAuthenticated: false });
     }
   },
-  
-  setUser: (user: User | null) => {
-    set({ user, isAuthenticated: !!user });
-  },
-  
-  setLoading: (loading: boolean) => {
-    set({ isLoading: loading });
-  }
+
+  setUser: (user) => set({ user, isAuthenticated: Boolean(user) }),
+
+  setLoading: (loading) => set({ isLoading: loading }),
 }));
 
 // Initialize auth state listener
 onAuthStateChanged(auth, (firebaseUser: FirebaseUser | null) => {
   const { setUser, setLoading } = useAuthStore.getState();
-  
+
   if (firebaseUser) {
     const user: User = {
       id: firebaseUser.uid,
-      username: firebaseUser.email || 'Utilisateur'
+      username: firebaseUser.email ?? 'Utilisateur',
     };
     setUser(user);
   } else {
     setUser(null);
   }
-  
+
   setLoading(false);
 });
+


### PR DESCRIPTION
## Summary
- clarifier la structure du store d'authentification
- sécuriser les appels login/logout avec des garde-fous

## Testing
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build` (fails: TypeScript errors in existing code)


------
https://chatgpt.com/codex/tasks/task_e_68a9bde232148327b73c19e84127f526