### PR TITLE
Improve UX feedback for project forms and modals

### DIFF
--- a/src/components/Project/ChecklistEditorModal.tsx
+++ b/src/components/Project/ChecklistEditorModal.tsx
@@ -5,6 +5,7 @@ import Input from '../UI/Input';
 import Button from '../UI/Button';
 import Checkbox from '../UI/Checkbox';
 import { Plus, Trash2, GripVertical, Eye, EyeOff } from 'lucide-react';
+import { useAlertStore } from '../../store/useAlertStore';
 import {
   DndContext,
   closestCenter,
@@ -131,8 +132,10 @@ const ChecklistEditorModal: React.FC<ChecklistEditorModalProps> = ({
   onReorderItems
 }) => {
   const [newItemText, setNewItemText] = useState('');
+  const [newItemError, setNewItemError] = useState('');
   const checklist = project.data[phase].checklist;
   const isDisabled = project.data[phase].validated;
+  const showAlert = useAlertStore(state => state.show);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -153,10 +156,14 @@ const ChecklistEditorModal: React.FC<ChecklistEditorModalProps> = ({
   };
 
   const handleAddItem = () => {
-    if (newItemText.trim()) {
-      onAddItem(newItemText.trim());
-      setNewItemText('');
+    if (!newItemText.trim()) {
+      setNewItemError('Le texte est requis');
+      return;
     }
+    onAddItem(newItemText.trim());
+    setNewItemText('');
+    setNewItemError('');
+    showAlert('Élément ajouté', "L'élément a été ajouté à la checklist.");
   };
 
   const getPhaseLabel = () => {
@@ -238,8 +245,14 @@ const ChecklistEditorModal: React.FC<ChecklistEditorModalProps> = ({
               <div className="flex-1">
                 <Input
                   value={newItemText}
-                  onChange={(e) => setNewItemText(e.target.value)}
+                  onChange={(e) => {
+                    setNewItemText(e.target.value);
+                    if (newItemError) {
+                      setNewItemError('');
+                    }
+                  }}
                   placeholder="Texte du nouvel élément..."
+                  error={newItemError}
                   onKeyPress={(e) => {
                     if (e.key === 'Enter') {
                       handleAddItem();

--- a/src/components/Project/SectionEditorModal.tsx
+++ b/src/components/Project/SectionEditorModal.tsx
@@ -25,6 +25,7 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useAlertStore } from '../../store/useAlertStore';
 
 interface SectionEditorModalProps {
   isOpen: boolean;
@@ -159,13 +160,16 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
   const [newSectionTitle, setNewSectionTitle] = useState('');
   const [newSectionPlaceholder, setNewSectionPlaceholder] = useState('');
   const [newSectionTooltip, setNewSectionTooltip] = useState('');
+  const [newSectionError, setNewSectionError] = useState('');
   const [editingSection, setEditingSection] = useState<ProjectSection | null>(null);
   const [editTitle, setEditTitle] = useState('');
   const [editPlaceholder, setEditPlaceholder] = useState('');
   const [editTooltip, setEditTooltip] = useState('');
+  const [editError, setEditError] = useState('');
 
   const sections = project.data[phase].sections;
   const isDisabled = project.data[phase].validated;
+  const showAlert = useAlertStore(state => state.show);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -195,20 +199,24 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
   };
 
   const handleAddSection = () => {
-    if (newSectionTitle.trim()) {
-      onAddSection({
-        title: newSectionTitle.trim(),
-        content: '',
-        internalOnly: false,
-        placeholder: newSectionPlaceholder.trim() || 'Saisissez le contenu de cette section...',
-        tooltipContent: newSectionTooltip.trim() || null,
-        isDefault: false,
-        isHidden: false
-      });
-      setNewSectionTitle('');
-      setNewSectionPlaceholder('');
-      setNewSectionTooltip('');
+    if (!newSectionTitle.trim()) {
+      setNewSectionError('Le titre est requis');
+      return;
     }
+    onAddSection({
+      title: newSectionTitle.trim(),
+      content: '',
+      internalOnly: false,
+      placeholder: newSectionPlaceholder.trim() || 'Saisissez le contenu de cette section...',
+      tooltipContent: newSectionTooltip.trim() || null,
+      isDefault: false,
+      isHidden: false
+    });
+    setNewSectionTitle('');
+    setNewSectionPlaceholder('');
+    setNewSectionTooltip('');
+    setNewSectionError('');
+    showAlert('Section ajoutée', 'La section a été ajoutée.');
   };
 
   const handleEditSection = (section: ProjectSection) => {
@@ -219,7 +227,11 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
   };
 
   const handleSaveEdit = () => {
-    if (editingSection && editTitle.trim()) {
+    if (editingSection && !editTitle.trim()) {
+      setEditError('Le titre est requis');
+      return;
+    }
+    if (editingSection) {
       onUpdateSection(editingSection.id, {
         title: editTitle.trim(),
         placeholder: editPlaceholder.trim() || 'Saisissez le contenu de cette section...',
@@ -229,6 +241,8 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
       setEditTitle('');
       setEditPlaceholder('');
       setEditTooltip('');
+      setEditError('');
+      showAlert('Section mise à jour', 'La section a été mise à jour.');
     }
   };
 
@@ -237,6 +251,7 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
     setEditTitle('');
     setEditPlaceholder('');
     setEditTooltip('');
+    setEditError('');
   };
 
   const visibleCount = sections.filter(section => !section.isHidden).length;
@@ -310,8 +325,14 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
               <Input
                 label="Titre de la section"
                 value={editTitle}
-                onChange={(e) => setEditTitle(e.target.value)}
+                onChange={(e) => {
+                  setEditTitle(e.target.value);
+                  if (editError) {
+                    setEditError('');
+                  }
+                }}
                 placeholder="Titre de la section"
+                error={editError}
               />
               <Textarea
                 label="Texte d'aide (placeholder)"
@@ -353,8 +374,14 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
               <Input
                 label="Titre de la section"
                 value={newSectionTitle}
-                onChange={(e) => setNewSectionTitle(e.target.value)}
+                onChange={(e) => {
+                  setNewSectionTitle(e.target.value);
+                  if (newSectionError) {
+                    setNewSectionError('');
+                  }
+                }}
                 placeholder="Titre de la nouvelle section"
+                error={newSectionError}
               />
               <Textarea
                 label="Texte d'aide (placeholder)"

--- a/src/components/Project/StakeholderFormModal.tsx
+++ b/src/components/Project/StakeholderFormModal.tsx
@@ -5,6 +5,7 @@ import Input from '../UI/Input';
 import Checkbox from '../UI/Checkbox';
 import Button from '../UI/Button';
 import { Save, X } from 'lucide-react';
+import { useAlertStore } from '../../store/useAlertStore';
 
 interface StakeholderFormModalProps {
   isOpen: boolean;
@@ -40,6 +41,14 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
     mandatoryFinal: false
   });
 
+  const [errors, setErrors] = useState({
+    firstName: '',
+    lastName: '',
+    role: ''
+  });
+
+  const showAlert = useAlertStore(state => state.show);
+
   const engagementOptions = [
     '',
     'Informé',
@@ -64,6 +73,7 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
           mandatoryOptions: stakeholder.mandatoryOptions,
           mandatoryFinal: stakeholder.mandatoryFinal
         });
+        setErrors({ firstName: '', lastName: '', role: '' });
       } else {
         setFormData({
           firstName: '',
@@ -77,18 +87,25 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
           mandatoryOptions: false,
           mandatoryFinal: false
         });
+        setErrors({ firstName: '', lastName: '', role: '' });
       }
     }
   }, [isOpen, stakeholder]);
 
   const handleSave = () => {
-    if (!formData.firstName.trim() || !formData.lastName.trim() || !formData.role.trim()) {
-      return;
-    }
+    const newErrors = {
+      firstName: formData.firstName.trim() ? '' : 'Le prénom est requis',
+      lastName: formData.lastName.trim() ? '' : 'Le nom est requis',
+      role: formData.role.trim() ? '' : 'Le rôle est requis'
+    };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
     onSave(formData);
+    showAlert('Partie prenante enregistrée', 'Les informations ont été sauvegardées.');
   };
 
   const handleClose = () => {
+    setErrors({ firstName: '', lastName: '', role: '' });
     onClose();
   };
 
@@ -104,15 +121,27 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
             <Input
               label="Prénom *"
               value={formData.firstName}
-              onChange={(e) => setFormData(prev => ({ ...prev, firstName: e.target.value }))}
+              onChange={(e) => {
+                setFormData(prev => ({ ...prev, firstName: e.target.value }));
+                if (errors.firstName) {
+                  setErrors(prev => ({ ...prev, firstName: '' }));
+                }
+              }}
               placeholder="Prénom"
+              error={errors.firstName}
               required
             />
             <Input
               label="Nom *"
               value={formData.lastName}
-              onChange={(e) => setFormData(prev => ({ ...prev, lastName: e.target.value }))}
+              onChange={(e) => {
+                setFormData(prev => ({ ...prev, lastName: e.target.value }));
+                if (errors.lastName) {
+                  setErrors(prev => ({ ...prev, lastName: '' }));
+                }
+              }}
               placeholder="Nom"
+              error={errors.lastName}
               required
             />
           </div>
@@ -149,8 +178,14 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
             <Input
               label="Rôle sur le projet *"
               value={formData.role}
-              onChange={(e) => setFormData(prev => ({ ...prev, role: e.target.value }))}
+              onChange={(e) => {
+                setFormData(prev => ({ ...prev, role: e.target.value }));
+                if (errors.role) {
+                  setErrors(prev => ({ ...prev, role: '' }));
+                }
+              }}
               placeholder="Chef de projet, Sponsor, Expert métier..."
+              error={errors.role}
               required
             />
             <div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -44,14 +44,30 @@ const Dashboard: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [projectName, setProjectName] = useState('');
   const [projectDescription, setProjectDescription] = useState('');
+  const [projectErrors, setProjectErrors] = useState({
+    name: '',
+    description: ''
+  });
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [editingProject, setEditingProject] = useState<EditingProject | null>(
     null
   );
+  const [editErrors, setEditErrors] = useState({
+    name: '',
+    description: ''
+  });
 
   const handleCreateProject = async (): Promise<void> => {
-    if (!projectName.trim() || !projectDescription.trim()) return;
+    if (!projectName.trim() || !projectDescription.trim()) {
+      setProjectErrors({
+        name: !projectName.trim() ? 'Le nom du projet est requis' : '',
+        description: !projectDescription.trim()
+          ? 'La description du projet est requise'
+          : ''
+      });
+      return;
+    }
 
     try {
       const projectId = await createProject(
@@ -60,6 +76,7 @@ const Dashboard: React.FC = () => {
       );
       setProjectName('');
       setProjectDescription('');
+      setProjectErrors({ name: '', description: '' });
       setIsModalOpen(false);
       showAlert('Projet créé', 'Le projet a été créé avec succès.', () => {
         navigate(`/project/${projectId}`);
@@ -84,8 +101,15 @@ const Dashboard: React.FC = () => {
       !editingProject ||
       !editingProject.name.trim() ||
       !editingProject.description.trim()
-    )
+    ) {
+      setEditErrors({
+        name: !editingProject?.name.trim() ? 'Le nom du projet est requis' : '',
+        description: !editingProject?.description.trim()
+          ? 'La description du projet est requise'
+          : ''
+      });
       return;
+    }
 
     try {
       await updateProjectDetails(
@@ -95,6 +119,8 @@ const Dashboard: React.FC = () => {
       );
       setIsEditModalOpen(false);
       setEditingProject(null);
+      setEditErrors({ name: '', description: '' });
+      showAlert('Projet modifié', 'Les modifications ont été enregistrées.');
     } catch (error) {
       console.error('Erreur lors de la modification du projet:', error);
       showAlert('Erreur', 'Erreur lors de la modification du projet. Veuillez réessayer.');
@@ -324,6 +350,7 @@ const Dashboard: React.FC = () => {
           setIsModalOpen(false);
           setProjectName('');
           setProjectDescription('');
+          setProjectErrors({ name: '', description: '' });
         }}
         title="Nouveau projet"
       >
@@ -331,16 +358,28 @@ const Dashboard: React.FC = () => {
           <Input
             label="Nom du projet"
             value={projectName}
-            onChange={(e) => setProjectName(e.target.value)}
+            onChange={(e) => {
+              setProjectName(e.target.value);
+              if (projectErrors.name) {
+                setProjectErrors(prev => ({ ...prev, name: '' }));
+              }
+            }}
             placeholder="Entrez le nom du projet"
+            error={projectErrors.name}
             required
           />
           <Textarea
             label="Description du projet"
             value={projectDescription}
-            onChange={(e) => setProjectDescription(e.target.value)}
+            onChange={(e) => {
+              setProjectDescription(e.target.value);
+              if (projectErrors.description) {
+                setProjectErrors(prev => ({ ...prev, description: '' }));
+              }
+            }}
             placeholder="Décrivez brièvement le projet..."
             rows={3}
+            error={projectErrors.description}
             required
           />
           <div className="flex justify-end space-x-3">
@@ -370,6 +409,7 @@ const Dashboard: React.FC = () => {
         onClose={() => {
           setIsEditModalOpen(false);
           setEditingProject(null);
+          setEditErrors({ name: '', description: '' });
         }}
         title="Modifier le projet"
       >
@@ -378,23 +418,31 @@ const Dashboard: React.FC = () => {
             label="Nom du projet"
             value={editingProject?.name ?? ''}
             onChange={(e) =>
-              setEditingProject((prev) =>
-                prev ? { ...prev, name: e.target.value } : prev
-              )
+              setEditingProject((prev) => {
+                if (editErrors.name) {
+                  setEditErrors(err => ({ ...err, name: '' }));
+                }
+                return prev ? { ...prev, name: e.target.value } : prev;
+              })
             }
             placeholder="Entrez le nom du projet"
+            error={editErrors.name}
             required
           />
           <Textarea
             label="Description du projet"
             value={editingProject?.description ?? ''}
             onChange={(e) =>
-              setEditingProject((prev) =>
-                prev ? { ...prev, description: e.target.value } : prev
-              )
+              setEditingProject((prev) => {
+                if (editErrors.description) {
+                  setEditErrors(err => ({ ...err, description: '' }));
+                }
+                return prev ? { ...prev, description: e.target.value } : prev;
+              })
             }
             placeholder="Décrivez brièvement le projet..."
             rows={3}
+            error={editErrors.description}
             required
           />
           <div className="flex justify-end space-x-3">


### PR DESCRIPTION
## Summary
- add field-level validation to project creation and edit modals
- surface validation and success alerts in stakeholder, checklist, and section editors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d76089b88327991027effc202271