### PR TITLE
feat: add dark mode with toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,10 +29,10 @@ const App: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background dark:bg-background-dark flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto" />
-          <p className="mt-4 text-gray-600">Chargement...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary dark:border-primary-dark mx-auto" />
+          <p className="mt-4 text-text dark:text-text-dark">Chargement...</p>
         </div>
       </div>
     );
@@ -43,7 +43,7 @@ const App: React.FC = () => {
 
   return (
     <Router>
-      <div className="min-h-screen bg-gray-50 pt-16">
+      <div className="min-h-screen bg-background dark:bg-background-dark pt-16">
         {isAuthenticated && <Header />}
         <Routes>
           <Route path="/login" element={isAuthenticated ? <Navigate to="/dashboard" /> : <Login />} />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuthStore } from '../../store/useAuthStore';
 import { useProjectStore } from '../../store/useProjectStore';
 import { useAlertStore } from '../../store/useAlertStore';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { LogOut, Home, Folder } from 'lucide-react';
+import { LogOut, Home, Folder, Moon, Sun } from 'lucide-react';
 import Button from '../UI/Button';
 
 const Header: React.FC = () => {
@@ -28,18 +28,36 @@ const Header: React.FC = () => {
   const isOnDashboard = location.pathname === '/dashboard';
   const isOnProject = location.pathname.startsWith('/project/');
 
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') === 'dark';
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (isDarkMode) {
+      root.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDarkMode]);
+
   return (
-    <header className="fixed top-0 w-full z-50 bg-primary text-background shadow-sm border-b border-primary">
+    <header className="fixed top-0 w-full z-50 bg-primary text-background shadow-sm border-b border-primary dark:bg-primary-dark dark:text-background-dark dark:border-primary-dark">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
-              <div className="h-8 w-8 bg-accent rounded-lg flex items-center justify-center">
-                <Folder className="h-4 w-4 text-background" />
+              <div className="h-8 w-8 bg-accent rounded-lg flex items-center justify-center dark:bg-accent-dark">
+                <Folder className="h-4 w-4 text-background dark:text-background-dark" />
               </div>
               <div>
                 <h1 className="text-xl font-bold">Scopilot</h1>
-                <p className="text-xs italic text-background/80">Cadrez. Engagez. Avancez.</p>
+                <p className="text-xs italic text-background/80 dark:text-background-dark/80">Cadrez. Engagez. Avancez.</p>
               </div>
             </div>
 
@@ -56,7 +74,7 @@ const Header: React.FC = () => {
 
             {isOnProject && currentProject && (
               <>
-                <div className="h-6 border-l border-background mx-4" />
+                <div className="h-6 border-l border-background mx-4 dark:border-background-dark" />
                 <div className="flex-1 text-center">
                   <span className="font-bold text-2xl">{currentProject.name}</span>
                 </div>
@@ -65,8 +83,15 @@ const Header: React.FC = () => {
           </div>
 
           <div className="flex items-center space-x-4">
-            <div className="h-6 border-l border-background mx-4" />
-            <span className="text-sm text-background/80">
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={isDarkMode ? Sun : Moon}
+              onClick={() => setIsDarkMode(!isDarkMode)}
+              aria-label="Basculer le mode sombre"
+            />
+            <div className="h-6 border-l border-background mx-4 dark:border-background-dark" />
+            <span className="text-sm text-background/80 dark:text-background-dark/80">
               Connecté en tant que <span className="font-medium">{user?.username}</span>
             </span>
             <Button

--- a/src/components/UI/Checkbox.tsx
+++ b/src/components/UI/Checkbox.tsx
@@ -25,15 +25,15 @@ const Checkbox: React.FC<CheckboxProps> = ({
           disabled={disabled}
           {...props}
         />
-        <div 
+        <div
           className={`
             w-5 h-5 border-2 rounded cursor-pointer transition-colors duration-200
-            ${checked 
-              ? 'bg-green-600 border-green-600' 
-              : 'bg-white border-gray-300 hover:border-gray-400'
+            ${checked
+              ? 'bg-green-600 border-green-600'
+              : 'bg-background border-gray-300 hover:border-gray-400 dark:bg-background-dark dark:border-gray-600 dark:hover:border-gray-500'
             }
-            ${disabled 
-              ? 'cursor-not-allowed opacity-50' 
+            ${disabled
+              ? 'cursor-not-allowed opacity-50'
               : 'cursor-pointer'
             }
             ${className}
@@ -41,19 +41,19 @@ const Checkbox: React.FC<CheckboxProps> = ({
           onClick={() => !disabled && props.onChange?.({ target: { checked: !checked } } as any)}
         >
           {checked && (
-            <Check className="w-3 h-3 text-white absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
+            <Check className="w-3 h-3 text-background absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
           )}
         </div>
       </div>
       {(label || description) && (
         <div className="flex-1">
           {label && (
-            <label className={`block text-sm font-medium cursor-pointer ${disabled ? 'text-gray-400 cursor-not-allowed' : 'text-gray-700'}`}>
+            <label className={`block text-sm font-medium cursor-pointer ${disabled ? 'text-gray-400 cursor-not-allowed' : 'text-text dark:text-text-dark'}`}>
               {label}
             </label>
           )}
           {description && (
-            <p className={`text-sm ${disabled ? 'text-gray-400' : 'text-gray-500'}`}>{description}</p>
+            <p className={`text-sm ${disabled ? 'text-gray-400' : 'text-text/80 dark:text-text-dark/80'}`}>{description}</p>
           )}
         </div>
       )}

--- a/src/components/UI/Input.tsx
+++ b/src/components/UI/Input.tsx
@@ -14,14 +14,15 @@ const Input: React.FC<InputProps> = ({
   return (
     <div className="space-y-1">
       {label && (
-        <label className="block text-sm font-medium text-text">
+        <label className="block text-sm font-medium text-text dark:text-text-dark">
           {label}
         </label>
       )}
       <input
         className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm
+          block w-full rounded-md border border-gray-300 bg-background px-3 py-2 shadow-sm
           placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+          dark:bg-background-dark dark:border-gray-600 dark:text-text-dark dark:placeholder-gray-500 dark:focus:ring-primary-dark dark:focus:border-primary-dark
           ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
           ${className}
         `}

--- a/src/components/UI/Modal.tsx
+++ b/src/components/UI/Modal.tsx
@@ -15,21 +15,21 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, modalCl
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen text-center sm:block">
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
+        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-black/50" onClick={onClose} />
         
         <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
           &#8203;
         </span>
         
-        <div className={`inline-block align-middle bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:align-middle sm:w-full ${modalClassName || 'sm:max-w-lg'}`}>
-          <div className="bg-white px-4 py-3 sm:px-4 sm:py-3 flex flex-col h-full">
+        <div className={`inline-block align-middle bg-secondary rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:align-middle sm:w-full dark:bg-secondary-dark ${modalClassName || 'sm:max-w-lg'}`}>
+          <div className="bg-secondary px-4 py-3 sm:px-4 sm:py-3 flex flex-col h-full dark:bg-secondary-dark">
             <div className="flex items-center justify-between mb-4 flex-shrink-0">
-              <h3 className="text-lg font-medium text-gray-900">
+              <h3 className="text-lg font-medium text-text dark:text-text-dark">
                 {title}
               </h3>
               <button
                 onClick={onClose}
-                className="text-gray-400 hover:text-gray-600 transition-colors"
+                className="text-text/60 hover:text-text transition-colors dark:text-text-dark/60 dark:hover:text-text-dark"
               >
                 <X className="h-5 w-5" />
               </button>

--- a/src/components/UI/Textarea.tsx
+++ b/src/components/UI/Textarea.tsx
@@ -14,14 +14,15 @@ const Textarea: React.FC<TextareaProps> = ({
   return (
     <div className="space-y-1">
       {label && (
-        <label className="block text-sm font-medium text-text">
+        <label className="block text-sm font-medium text-text dark:text-text-dark">
           {label}
         </label>
       )}
       <textarea
         className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm
+          block w-full rounded-md border border-gray-300 bg-background px-3 py-2 shadow-sm
           placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+          dark:bg-background-dark dark:border-gray-600 dark:text-text-dark dark:placeholder-gray-500 dark:focus:ring-primary-dark dark:focus:border-primary-dark
           ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
           ${className}
         `}

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
   }
   
   body {
-    @apply bg-background text-text;
+    @apply bg-background text-text dark:bg-background-dark dark:text-text-dark;
   }
 }
 
@@ -18,15 +18,15 @@
   }
   
   .btn-primary {
-    @apply bg-primary text-background hover:bg-primary/90 focus:ring-accent;
+    @apply bg-primary text-background hover:bg-primary/90 focus:ring-accent dark:bg-primary-dark dark:text-background-dark dark:hover:bg-primary-dark/90 dark:focus:ring-accent-dark;
   }
 
   .btn-secondary {
-    @apply bg-white border border-gray-300 text-text hover:bg-gray-50 hover:border-gray-400 focus:ring-secondary shadow-sm;
+    @apply bg-secondary border border-gray-300 text-text hover:bg-secondary/80 hover:border-gray-400 focus:ring-secondary shadow-sm dark:bg-secondary-dark dark:border-gray-600 dark:text-text-dark dark:hover:bg-secondary-dark/80 dark:hover:border-gray-500 dark:focus:ring-secondary-dark;
   }
-  
+
   .card {
-    @apply bg-secondary text-text rounded-lg shadow-sm;
+    @apply bg-secondary text-text rounded-lg shadow-sm dark:bg-secondary-dark dark:text-text-dark;
   }
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -220,7 +220,7 @@ const Dashboard: React.FC = () => {
     return (
       <li
         key={project.id}
-        className="bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-200"
+        className="bg-secondary dark:bg-secondary-dark rounded-xl shadow-md hover:shadow-lg transition-shadow duration-200"
       >
         <div
           className="p-6 cursor-pointer flex flex-col h-full"
@@ -228,10 +228,10 @@ const Dashboard: React.FC = () => {
         >
           <div className="flex items-start justify-between mb-4">
             <div className="flex-1 min-w-0">
-              <p className="text-lg font-semibold text-gray-900 truncate">
+              <p className="text-lg font-semibold text-text dark:text-text-dark truncate">
                 {project.name}
               </p>
-              <p className="mt-1 text-sm text-gray-500 truncate">
+              <p className="mt-1 text-sm text-text/80 dark:text-text-dark/80 truncate">
                 {project.description}
               </p>
             </div>
@@ -258,7 +258,7 @@ const Dashboard: React.FC = () => {
               </div>
             </div>
           </div>
-          <div className="mt-auto flex items-center justify-between text-sm text-gray-500">
+          <div className="mt-auto flex items-center justify-between text-sm text-text/80 dark:text-text-dark/80">
             <div className="flex items-center">
               <Calendar className="h-4 w-4 mr-1" />
               {formatDate(project.createdAt)}
@@ -276,14 +276,14 @@ const Dashboard: React.FC = () => {
                 {getPhaseLabel(project)}
               </span>
               <div className="flex items-center space-x-2">
-                <BarChart3 className="h-4 w-4 text-gray-400" />
-                <div className="w-16 bg-gray-200 rounded-full h-1.5">
+                <BarChart3 className="h-4 w-4 text-text/60 dark:text-text-dark/60" />
+                <div className="w-16 bg-background dark:bg-background-dark rounded-full h-1.5">
                   <div
                     className="bg-green-600 h-1.5 rounded-full transition-all duration-300"
                     style={{ width: `${progress.percentage}%` }}
                   />
                 </div>
-                <span className="text-xs text-gray-600 font-medium min-w-[2rem]">
+                <span className="text-xs text-text/80 dark:text-text-dark/80 font-medium min-w-[2rem]">
                   {progress.completed}/{progress.total}
                 </span>
               </div>
@@ -298,8 +298,8 @@ const Dashboard: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="flex justify-between items-center mb-8">
       <div>
-          <h1 className="text-3xl font-bold text-gray-900">Mes projets</h1>
-          <p className="mt-2 text-gray-600">
+          <h1 className="text-3xl font-bold text-text dark:text-text-dark">Mes projets</h1>
+          <p className="mt-2 text-text/80 dark:text-text-dark/80">
             Formalisez vos projets pas à pas, avant démarrage
           </p>
         </div>
@@ -314,16 +314,16 @@ const Dashboard: React.FC = () => {
 
       {isLoadingProjects ? (
         <div className="text-center py-12">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto" />
-          <p className="mt-4 text-gray-600">Chargement des projets...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary dark:border-primary-dark mx-auto" />
+          <p className="mt-4 text-text dark:text-text-dark">Chargement des projets...</p>
         </div>
       ) : projects.length === 0 ? (
         <div className="text-center py-12">
-          <Folder className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-2 text-sm font-medium text-gray-900">
+          <Folder className="mx-auto h-12 w-12 text-text/60 dark:text-text-dark/60" />
+          <h3 className="mt-2 text-sm font-medium text-text dark:text-text-dark">
             Aucun projet
           </h3>
-          <p className="mt-1 text-sm text-gray-500">
+          <p className="mt-1 text-sm text-text/80 dark:text-text-dark/80">
             Commencez par créer votre premier projet FEL.
           </p>
           <div className="mt-6">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -55,24 +55,24 @@ const Login: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
-      <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-xl shadow-lg">
+    <div className="min-h-screen flex items-center justify-center bg-background dark:bg-background-dark">
+      <div className="max-w-md w-full space-y-8 p-8 bg-secondary dark:bg-secondary-dark rounded-xl shadow-lg">
         <div className="text-center">
-          <div className="mx-auto h-12 w-12 bg-blue-600 rounded-lg flex items-center justify-center">
-            <LogIn className="h-6 w-6 text-white" />
+          <div className="mx-auto h-12 w-12 bg-primary rounded-lg flex items-center justify-center dark:bg-primary-dark">
+            <LogIn className="h-6 w-6 text-background dark:text-background-dark" />
           </div>
-          <h2 className="mt-6 text-3xl font-bold text-gray-900">Scopilot</h2>
-          <p className="mt-2 text-sm text-gray-600 italic">Cadrez. Engagez. Avancez.</p>
+          <h2 className="mt-6 text-3xl font-bold text-text dark:text-text-dark">Scopilot</h2>
+          <p className="mt-2 text-sm text-text/80 italic dark:text-text-dark/80">Cadrez. Engagez. Avancez.</p>
         </div>
-        
+
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="flex items-center space-x-2 text-red-600 bg-red-50 p-3 rounded-lg">
+            <div className="flex items-center space-x-2 text-red-600 bg-red-50 p-3 rounded-lg dark:text-red-400 dark:bg-red-900/20">
               <AlertCircle className="h-4 w-4" />
               <span className="text-sm">{error}</span>
             </div>
           )}
-          
+
           <div className="space-y-4">
             <Input
               label="Email"
@@ -82,7 +82,7 @@ const Login: React.FC = () => {
               placeholder="votre@email.com"
               required
             />
-            
+
             <Input
               label="Mot de passe"
               type="password"
@@ -103,7 +103,7 @@ const Login: React.FC = () => {
             {isLoading ? 'Connexion...' : 'Se connecter'}
           </Button>
         </form>
-        
+
       </div>
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,17 +1,23 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {
       colors: {
         primary: '#1e40af',
+        'primary-dark': '#1e3a8a',
         secondary: '#f3f4f6',
+        'secondary-dark': '#374151',
         background: '#f9fafb',
+        'background-dark': '#1f2937',
         text: '#111827',
+        'text-dark': '#f9fafb',
         accent: '#f59e0b',
+        'accent-dark': '#d97706',
       },
       width: {
         '144': '36rem', // 576px (320px * 1.8 = 576px)


### PR DESCRIPTION
## Summary
- configure Tailwind for class-based dark mode and extend color palette for dark variants
- add theme toggle in header and apply dark styles across layout and UI components
- update pages and shared components to support light and dark themes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a9da561a10832791e89df414ca1168