### PR TITLE
feat(ui): refonte palette et ajout du dark mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,10 +29,10 @@ const App: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto" />
-          <p className="mt-4 text-gray-600">Chargement...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto" />
+          <p className="mt-4 text-text/70">Chargement...</p>
         </div>
       </div>
     );
@@ -43,7 +43,7 @@ const App: React.FC = () => {
 
   return (
     <Router>
-      <div className="min-h-screen bg-gray-50 pt-16">
+      <div className="min-h-screen bg-background text-text pt-16">
         {isAuthenticated && <Header />}
         <Routes>
           <Route path="/login" element={isAuthenticated ? <Navigate to="/dashboard" /> : <Login />} />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -5,6 +5,7 @@ import { useAlertStore } from '../../store/useAlertStore';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { LogOut, Home, Folder } from 'lucide-react';
 import Button from '../UI/Button';
+import ThemeToggle from '../UI/ThemeToggle';
 
 const Header: React.FC = () => {
   const { user, logout } = useAuthStore();
@@ -65,6 +66,7 @@ const Header: React.FC = () => {
           </div>
 
           <div className="flex items-center space-x-4">
+            <ThemeToggle />
             <div className="h-6 border-l border-background mx-4" />
             <span className="text-sm text-background/80">
               Connecté en tant que <span className="font-medium">{user?.username}</span>

--- a/src/components/UI/AlertDialog.tsx
+++ b/src/components/UI/AlertDialog.tsx
@@ -47,10 +47,10 @@ const AlertDialog: React.FC = () => {
         </div>
         
         <div className="space-y-2">
-          <h3 className="text-lg font-medium text-gray-900">
+          <h3 className="text-lg font-medium text-text">
             {title}
           </h3>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-text/70">
             {message}
           </p>
         </div>

--- a/src/components/UI/Checkbox.tsx
+++ b/src/components/UI/Checkbox.tsx
@@ -25,15 +25,15 @@ const Checkbox: React.FC<CheckboxProps> = ({
           disabled={disabled}
           {...props}
         />
-        <div 
+        <div
           className={`
-            w-5 h-5 border-2 rounded cursor-pointer transition-colors duration-200
-            ${checked 
-              ? 'bg-green-600 border-green-600' 
-              : 'bg-white border-gray-300 hover:border-gray-400'
+            w-5 h-5 border-2 rounded transition-colors duration-200
+            ${checked
+              ? 'bg-accent border-accent'
+              : 'bg-background border-text/40 hover:border-text/60'
             }
-            ${disabled 
-              ? 'cursor-not-allowed opacity-50' 
+            ${disabled
+              ? 'cursor-not-allowed opacity-50'
               : 'cursor-pointer'
             }
             ${className}
@@ -41,19 +41,19 @@ const Checkbox: React.FC<CheckboxProps> = ({
           onClick={() => !disabled && props.onChange?.({ target: { checked: !checked } } as any)}
         >
           {checked && (
-            <Check className="w-3 h-3 text-white absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
+            <Check className="w-3 h-3 text-background absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
           )}
         </div>
       </div>
       {(label || description) && (
         <div className="flex-1">
           {label && (
-            <label className={`block text-sm font-medium cursor-pointer ${disabled ? 'text-gray-400 cursor-not-allowed' : 'text-gray-700'}`}>
+            <label className={`block text-sm font-medium cursor-pointer ${disabled ? 'text-text/40 cursor-not-allowed' : 'text-text'}`}>
               {label}
             </label>
           )}
           {description && (
-            <p className={`text-sm ${disabled ? 'text-gray-400' : 'text-gray-500'}`}>{description}</p>
+            <p className={`text-sm ${disabled ? 'text-text/40' : 'text-text/70'}`}>{description}</p>
           )}
         </div>
       )}

--- a/src/components/UI/Input.tsx
+++ b/src/components/UI/Input.tsx
@@ -20,8 +20,8 @@ const Input: React.FC<InputProps> = ({
       )}
       <input
         className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm
-          placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+          block w-full rounded-md border border-text/20 bg-background px-3 py-2 shadow-sm
+          placeholder-text/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
           ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
           ${className}
         `}

--- a/src/components/UI/Modal.tsx
+++ b/src/components/UI/Modal.tsx
@@ -15,21 +15,21 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, modalCl
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen text-center sm:block">
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
+        <div className="fixed inset-0 bg-text/60 transition-opacity" onClick={onClose} />
         
         <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
           &#8203;
         </span>
         
-        <div className={`inline-block align-middle bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:align-middle sm:w-full ${modalClassName || 'sm:max-w-lg'}`}>
-          <div className="bg-white px-4 py-3 sm:px-4 sm:py-3 flex flex-col h-full">
+        <div className={`inline-block align-middle bg-background rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:align-middle sm:w-full ${modalClassName || 'sm:max-w-lg'}`}>
+          <div className="bg-background px-4 py-3 sm:px-4 sm:py-3 flex flex-col h-full">
             <div className="flex items-center justify-between mb-4 flex-shrink-0">
-              <h3 className="text-lg font-medium text-gray-900">
+              <h3 className="text-lg font-medium text-text">
                 {title}
               </h3>
               <button
                 onClick={onClose}
-                className="text-gray-400 hover:text-gray-600 transition-colors"
+                className="text-text/60 hover:text-text transition-colors"
               >
                 <X className="h-5 w-5" />
               </button>

--- a/src/components/UI/Textarea.tsx
+++ b/src/components/UI/Textarea.tsx
@@ -20,8 +20,8 @@ const Textarea: React.FC<TextareaProps> = ({
       )}
       <textarea
         className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm
-          placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+          block w-full rounded-md border border-text/20 bg-background px-3 py-2 shadow-sm
+          placeholder-text/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
           ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
           ${className}
         `}

--- a/src/components/UI/ThemeToggle.tsx
+++ b/src/components/UI/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import Button from './Button';
+import { useThemeStore } from '../../store/useThemeStore';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggle } = useThemeStore();
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      icon={theme === 'dark' ? Sun : Moon}
+      onClick={toggle}
+      aria-label="Changer de thème"
+    >
+      {theme === 'dark' ? 'Clair' : 'Sombre'}
+    </Button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/UI/TooltipIcon.tsx
+++ b/src/components/UI/TooltipIcon.tsx
@@ -13,7 +13,7 @@ const TooltipIcon: React.FC<TooltipIconProps> = ({ content, className = '' }) =>
     <div className={`relative inline-block ${className}`}>
       <button
         type="button"
-        className="ml-2 text-gray-400 hover:text-gray-600 transition-colors duration-200"
+        className="ml-2 text-text/60 hover:text-text transition-colors duration-200"
         onMouseEnter={() => setIsVisible(true)}
         onMouseLeave={() => setIsVisible(false)}
         onFocus={() => setIsVisible(true)}
@@ -23,8 +23,8 @@ const TooltipIcon: React.FC<TooltipIconProps> = ({ content, className = '' }) =>
       </button>
       
       {isVisible && (
-        <div className="absolute left-0 top-6 z-50 w-144 p-3 bg-gray-800 text-white text-xs rounded-lg shadow-lg">
-          <div className="absolute -top-1 left-2 w-2 h-2 bg-gray-800 transform rotate-45"></div>
+        <div className="absolute left-0 top-6 z-50 w-144 p-3 bg-secondary text-text text-xs rounded-lg shadow-lg border border-text/10">
+          <div className="absolute -top-1 left-2 w-2 h-2 bg-secondary transform rotate-45 border border-text/10"></div>
           <div className="whitespace-pre-wrap">{content}</div>
         </div>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -3,10 +3,26 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --color-primary: 37 99 235; /* #2563eb */
+    --color-secondary: 226 232 240; /* #e2e8f0 */
+    --color-background: 248 250 252; /* #f8fafc */
+    --color-text: 30 41 59; /* #1e293b */
+    --color-accent: 14 165 233; /* #0ea5e9 */
+  }
+
+  .dark {
+    --color-primary: 59 130 246; /* #3b82f6 */
+    --color-secondary: 30 41 59; /* #1e293b */
+    --color-background: 15 23 42; /* #0f172a */
+    --color-text: 241 245 249; /* #f1f5f9 */
+    --color-accent: 45 212 191; /* #2dd4bf */
+  }
+
   html {
     font-family: 'Inter', system-ui, sans-serif;
   }
-  
+
   body {
     @apply bg-background text-text;
   }
@@ -22,7 +38,7 @@
   }
 
   .btn-secondary {
-    @apply bg-white border border-gray-300 text-text hover:bg-gray-50 hover:border-gray-400 focus:ring-secondary shadow-sm;
+    @apply bg-secondary border border-text/10 text-text hover:bg-secondary/80 focus:ring-accent shadow-sm;
   }
   
   .card {
@@ -33,22 +49,23 @@
 /* RichTextEditor custom styles */
 .quill-editor-wrapper .ql-editor {
   min-height: 120px;
-  background-color: #ffffff;
+  background-color: rgb(var(--color-background));
+  color: rgb(var(--color-text));
 }
 
 .quill-editor-wrapper .ql-toolbar {
-  background-color: #f3f4f6;
-  border-bottom: 1px solid #e5e7eb;
+  background-color: rgb(var(--color-secondary));
+  border-bottom: 1px solid rgb(var(--color-secondary) / 0.5);
 }
 
 /* Read-only editor styles */
 .quill-editor-wrapper .ql-container.ql-disabled {
-  background-color: #f9fafb;
-  border-color: #e5e7eb;
+  background-color: rgb(var(--color-background));
+  border-color: rgb(var(--color-secondary) / 0.5);
 }
 
 .quill-editor-wrapper .ql-editor.ql-disabled {
-  color: #6b7280;
+  color: rgb(var(--color-text) / 0.7);
 }
 
 .quill-editor-wrapper.read-only .ql-toolbar {
@@ -56,7 +73,7 @@
 }
 
 .quill-editor-wrapper.read-only .ql-container {
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid rgb(var(--color-secondary) / 0.5);
 }
 
 .is-exporting-pdf .ql-toolbar {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { useThemeStore } from './store/useThemeStore'
+
+useThemeStore.getState().init()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/store/useThemeStore.ts
+++ b/src/store/useThemeStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeState {
+  theme: Theme;
+}
+
+interface ThemeActions {
+  init: () => void;
+  toggle: () => void;
+}
+
+export const useThemeStore = create<ThemeState & ThemeActions>((set) => ({
+  theme: 'light',
+  init: () => {
+    const stored = (localStorage.getItem('theme') as Theme) ||
+      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    document.documentElement.classList.toggle('dark', stored === 'dark');
+    set({ theme: stored });
+  },
+  toggle: () => set((state) => {
+    const next = state.theme === 'light' ? 'dark' : 'light';
+    document.documentElement.classList.toggle('dark', next === 'dark');
+    localStorage.setItem('theme', next);
+    return { theme: next };
+  }),
+}));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -7,11 +8,11 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: '#1e40af',
-        secondary: '#f3f4f6',
-        background: '#f9fafb',
-        text: '#111827',
-        accent: '#f59e0b',
+        primary: 'rgb(var(--color-primary) / <alpha-value>)',
+        secondary: 'rgb(var(--color-secondary) / <alpha-value>)',
+        background: 'rgb(var(--color-background) / <alpha-value>)',
+        text: 'rgb(var(--color-text) / <alpha-value>)',
+        accent: 'rgb(var(--color-accent) / <alpha-value>)',
       },
       width: {
         '144': '36rem', // 576px (320px * 1.8 = 576px)


### PR DESCRIPTION
## Summary
- refonte des couleurs en mode clair et sombre via des variables CSS
- ajout d'un store et d'un bouton pour basculer entre les thèmes
- harmonisation des composants avec la nouvelle palette

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e560e4408327a9b440b0bb0f091d