### PR TITLE
feat: add linear-inspired color palette

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,12 +3,30 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --background: 210 20% 98%; /* light gray */
+    --foreground: 222 47% 11%; /* dark gray text */
+    --muted: 210 16% 86%;
+    --card: 0 0% 100%;
+    --accent: 238 84% 67%; /* indigo accent */
+    --accent-foreground: 0 0% 100%;
+  }
+
+  .dark {
+    --background: 220 15% 12%; /* anthracite */
+    --foreground: 0 0% 98%; /* light text */
+    --muted: 217 15% 28%;
+    --card: 220 15% 18%;
+    --accent: 238 84% 67%; /* same accent */
+    --accent-foreground: 0 0% 100%;
+  }
+
   html {
     font-family: 'Inter', system-ui, sans-serif;
   }
-  
+
   body {
-    @apply bg-background text-text;
+    @apply bg-background text-foreground;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -7,11 +8,17 @@ export default {
   theme: {
     extend: {
       colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        muted: 'hsl(var(--muted))',
+        card: 'hsl(var(--card))',
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
         primary: '#1e40af',
         secondary: '#f3f4f6',
-        background: '#f9fafb',
         text: '#111827',
-        accent: '#f59e0b',
       },
       width: {
         '144': '36rem', // 576px (320px * 1.8 = 576px)


### PR DESCRIPTION
## Summary
- add neutral color palette with subtle indigo accent
- wire up light and dark modes via CSS variables and Tailwind

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e87f27208327b088cb0edb09c4d9