### PR TITLE
feat: add dark mode toggle with persistent theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Scopilot - Gestion de projets FEL</title>
+    <script>
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,10 +29,10 @@ const App: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto" />
-          <p className="mt-4 text-gray-600">Chargement...</p>
+          <p className="mt-4 text-foreground/80">Chargement...</p>
         </div>
       </div>
     );
@@ -43,7 +43,7 @@ const App: React.FC = () => {
 
   return (
     <Router>
-      <div className="min-h-screen bg-gray-50 pt-16">
+      <div className="min-h-screen bg-background text-foreground pt-16">
         {isAuthenticated && <Header />}
         <Routes>
           <Route path="/login" element={isAuthenticated ? <Navigate to="/dashboard" /> : <Login />} />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -3,7 +3,7 @@ import { useAuthStore } from '../../store/useAuthStore';
 import { useProjectStore } from '../../store/useProjectStore';
 import { useAlertStore } from '../../store/useAlertStore';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { LogOut, Home, Folder } from 'lucide-react';
+import { LogOut, Home, Folder, Sun, Moon } from 'lucide-react';
 import Button from '../UI/Button';
 
 const Header: React.FC = () => {
@@ -12,6 +12,18 @@ const Header: React.FC = () => {
   const showAlert = useAlertStore(state => state.show);
   const navigate = useNavigate();
   const location = useLocation();
+
+  const [theme, setTheme] = React.useState<'light' | 'dark'>(
+    (localStorage.getItem('theme') as 'light' | 'dark') || 'light'
+  );
+
+  React.useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
 
   const handleLogout = async () => {
     try {
@@ -69,6 +81,14 @@ const Header: React.FC = () => {
             <span className="text-sm text-background/80">
               Connecté en tant que <span className="font-medium">{user?.username}</span>
             </span>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={theme === 'light' ? Moon : Sun}
+              onClick={toggleTheme}
+            >
+              {theme === 'light' ? 'Sombre' : 'Clair'}
+            </Button>
             <Button
               variant="secondary"
               size="sm"

--- a/src/components/Project/Checklist.tsx
+++ b/src/components/Project/Checklist.tsx
@@ -32,16 +32,16 @@ const Checklist: React.FC<ChecklistProps> = ({ items, onItemChange, isDisabled =
                 title="Éditer la checklist"
               />
             )}
-            <h3 className="text-lg font-medium text-gray-900">Checklist de maturité</h3>
+            <h3 className="text-lg font-medium text-foreground">Checklist de maturité</h3>
           </div>
           <div className="flex items-center space-x-3">
-            <div className="w-32 bg-gray-200 rounded-full h-2">
+            <div className="w-32 bg-muted rounded-full h-2">
               <div 
                 className="bg-primary h-2 rounded-full transition-all duration-300"
                 style={{ width: `${progressPercentage}%` }}
               />
             </div>
-            <span className="text-sm text-gray-600 font-medium min-w-[3rem]">
+            <span className="text-sm text-foreground/80 font-medium min-w-[3rem]">
               {completedCount}/{totalCount}
             </span>
           </div>

--- a/src/components/Project/ChecklistEditorModal.tsx
+++ b/src/components/Project/ChecklistEditorModal.tsx
@@ -72,21 +72,21 @@ const SortableItem: React.FC<SortableItemProps> = ({
       ref={setNodeRef}
       style={style}
       className={`
-        flex items-center space-x-3 p-3 bg-white border border-gray-200 rounded-lg
-        ${item.isHidden ? 'opacity-60 bg-gray-50' : ''}
+        flex items-center space-x-3 p-3 bg-card border border-muted rounded-lg
+        ${item.isHidden ? 'opacity-60 bg-muted' : ''}
         ${isDragging ? 'shadow-lg' : 'shadow-sm'}
       `}
     >
       <div
         {...attributes}
         {...listeners}
-        className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600"
+        className="cursor-grab active:cursor-grabbing text-muted hover:text-foreground"
       >
         <GripVertical className="h-4 w-4" />
       </div>
       
       <div className="flex-1 min-w-0">
-        <span className={`text-sm ${item.isHidden ? 'text-gray-500 line-through' : 'text-gray-900'}`}>
+        <span className={`text-sm ${item.isHidden ? 'text-foreground/70 line-through' : 'text-foreground'}`}>
           {item.text}
         </span>
         {item.isDefault && (
@@ -193,22 +193,22 @@ const ChecklistEditorModal: React.FC<ChecklistEditorModalProps> = ({
           </div>
         )}
 
-        <div className="bg-gray-50 p-3 rounded-lg">
+        <div className="bg-muted p-3 rounded-lg">
           <div className="flex justify-between items-center text-sm">
-            <span className="text-gray-600">
+            <span className="text-foreground/80">
               Éléments visibles: <strong>{visibleCount}</strong> sur <strong>{totalCount}</strong>
             </span>
-            <span className="text-gray-600">
+            <span className="text-foreground/80">
               Éléments par défaut: <strong>{checklist.filter(item => item.isDefault).length}</strong>
             </span>
           </div>
         </div>
 
         <div className="space-y-3">
-          <h4 className="text-sm font-medium text-gray-900">Éléments de la checklist</h4>
-          
+          <h4 className="text-sm font-medium text-foreground">Éléments de la checklist</h4>
+
           {checklist.length === 0 ? (
-            <p className="text-sm text-gray-500 italic text-center py-4">
+            <p className="text-sm text-foreground/70 italic text-center py-4">
               Aucun élément dans cette checklist
             </p>
           ) : (
@@ -239,8 +239,8 @@ const ChecklistEditorModal: React.FC<ChecklistEditorModalProps> = ({
         </div>
 
         {!isDisabled && (
-          <div className="border-t border-gray-200 pt-4">
-            <h4 className="text-sm font-medium text-gray-900 mb-3">Ajouter un nouvel élément</h4>
+          <div className="border-t border-muted pt-4">
+            <h4 className="text-sm font-medium text-foreground mb-3">Ajouter un nouvel élément</h4>
             <div className="flex space-x-3">
               <div className="flex-1">
                 <Input
@@ -272,7 +272,7 @@ const ChecklistEditorModal: React.FC<ChecklistEditorModalProps> = ({
           </div>
         )}
 
-        <div className="flex justify-end pt-4 border-t border-gray-200">
+        <div className="flex justify-end pt-4 border-t border-muted">
           <Button
             variant="secondary"
             onClick={onClose}

--- a/src/components/Project/CustomFilterModal.tsx
+++ b/src/components/Project/CustomFilterModal.tsx
@@ -59,12 +59,12 @@ const CustomFilterModal: React.FC<CustomFilterModalProps> = ({
       title="Sélection personnalisée des sections"
       modalClassName="sm:max-w-2xl sm:max-h-[90vh]"
     >
-      <div className="space-y-4">
+      <div className="space-y-4 text-foreground">
 
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
             {localSections.map((section) => (
-              <div key={section.id} className="flex items-center space-x-2 p-2 bg-white border border-gray-200 rounded">
+              <div key={section.id} className="flex items-center space-x-2 p-2 bg-card border border-muted rounded">
                 <Checkbox
                   checked={section.isVisibleInPreview}
                   onChange={(e) => handleToggleSection(section.id, e.target.checked)}
@@ -82,7 +82,7 @@ const CustomFilterModal: React.FC<CustomFilterModalProps> = ({
           </div>
         </div>
 
-        <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200">
+        <div className="flex justify-end space-x-3 pt-4 border-t border-muted">
           <Button
             variant="secondary"
             onClick={handleCancel}

--- a/src/components/Project/ExportPreviewModal.tsx
+++ b/src/components/Project/ExportPreviewModal.tsx
@@ -138,7 +138,7 @@ const ExportPreviewModal: React.FC<ExportPreviewModalProps> = ({
     >
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h4 className="text-sm font-medium text-gray-900">Mode d'exportation :</h4>
+          <h4 className="text-sm font-medium text-foreground">Mode d'exportation :</h4>
           <div className="flex items-center space-x-3">
             <Button
               variant={filterMode === 'internal' ? 'primary' : 'secondary'}
@@ -163,7 +163,7 @@ const ExportPreviewModal: React.FC<ExportPreviewModalProps> = ({
             </Button>
             
             {/* Séparateur */}
-            <div className="h-6 border-l border-gray-300 mx-2"></div>
+            <div className="h-6 border-l border-muted mx-2"></div>
             
             {/* Bouton Générer PDF */}
             <Button
@@ -178,11 +178,11 @@ const ExportPreviewModal: React.FC<ExportPreviewModalProps> = ({
           </div>
         </div>
 
-        <div ref={pdfContentRef} className="space-y-6 max-h-[50vh] overflow-y-auto border border-gray-200 rounded-lg p-4 bg-white">
+        <div ref={pdfContentRef} className="space-y-6 max-h-[50vh] overflow-y-auto border border-muted rounded-lg p-4 bg-card">
           <div className="text-center">
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">{project.name}</h1>
-            <h2 className="text-lg font-semibold text-gray-700">{getPhaseLabel()}</h2>
-            <div className="mt-2 text-sm text-gray-500">
+            <h1 className="text-2xl font-bold text-foreground mb-2">{project.name}</h1>
+            <h2 className="text-lg font-semibold text-foreground/80">{getPhaseLabel()}</h2>
+            <div className="mt-2 text-sm text-foreground/70">
               Généré le {new Date().toLocaleDateString('fr-FR')}
             </div>
           </div>
@@ -193,7 +193,7 @@ const ExportPreviewModal: React.FC<ExportPreviewModalProps> = ({
               .map((section) => (
                 <div key={section.id} className="space-y-2">
                   <div className="flex items-center space-x-2">
-                    <h3 className="text-lg font-medium text-gray-900">{section.title}</h3>
+                    <h3 className="text-lg font-medium text-foreground">{section.title}</h3>
                     {section.internalOnly && (
                       <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
                         Usage interne
@@ -212,8 +212,8 @@ const ExportPreviewModal: React.FC<ExportPreviewModalProps> = ({
               ))}
 
             {project.data.notes && (
-              <div className="space-y-2 border-t border-gray-200 pt-6">
-                <h3 className="text-lg font-medium text-gray-900">Notes du projet</h3>
+              <div className="space-y-2 border-t border-muted pt-6">
+                <h3 className="text-lg font-medium text-foreground">Notes du projet</h3>
                 <div className="read-only">
                   <RichTextEditor
                     value={project.data.notes}
@@ -227,7 +227,7 @@ const ExportPreviewModal: React.FC<ExportPreviewModalProps> = ({
 
             {visibleSectionsCount === 0 && (
               <div className="text-center py-8">
-                <p className="text-gray-500 italic">
+                <p className="text-foreground/70 italic">
                   Aucune section sélectionnée pour l'export
                 </p>
               </div>

--- a/src/components/Project/InitialPhaseViewModal.tsx
+++ b/src/components/Project/InitialPhaseViewModal.tsx
@@ -52,14 +52,14 @@ const InitialPhaseViewModal: React.FC<InitialPhaseViewModalProps> = ({
         )}
 
         {visibleSections.length === 0 ? (
-          <p className="text-sm text-gray-500 italic text-center py-8">
+          <p className="text-sm text-foreground/70 italic text-center py-8">
             Aucune section visible dans l'opportunité
           </p>
         ) : (
           <div className="space-y-6">
             {visibleSections.map((section) => (
               <div key={section.id} className="space-y-2">
-                <h3 className="text-lg font-medium text-gray-900 flex items-center">
+                <h3 className="text-lg font-medium text-foreground flex items-center">
                   {section.title}
                   {section.internalOnly && (
                     <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">

--- a/src/components/Project/SectionEditorModal.tsx
+++ b/src/components/Project/SectionEditorModal.tsx
@@ -76,21 +76,21 @@ const SortableItem: React.FC<SortableItemProps> = ({
       ref={setNodeRef}
       style={style}
       className={`
-        flex items-center space-x-3 p-3 bg-white border border-gray-200 rounded-lg
-        ${section.isHidden ? 'opacity-60 bg-gray-50' : ''}
+        flex items-center space-x-3 p-3 bg-card border border-muted rounded-lg
+        ${section.isHidden ? 'opacity-60 bg-muted' : ''}
         ${isDragging ? 'shadow-lg' : 'shadow-sm'}
       `}
     >
       <div
         {...attributes}
         {...listeners}
-        className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600"
+        className="cursor-grab active:cursor-grabbing text-muted hover:text-foreground"
       >
         <GripVertical className="h-4 w-4" />
       </div>
       
       <div className="flex-1 min-w-0">
-        <span className={`text-sm font-medium ${section.isHidden ? 'text-gray-500 line-through' : 'text-gray-900'}`}>
+        <span className={`text-sm font-medium ${section.isHidden ? 'text-foreground/70 line-through' : 'text-foreground'}`}>
           {section.title}
         </span>
         {section.isDefault && (
@@ -99,7 +99,7 @@ const SortableItem: React.FC<SortableItemProps> = ({
           </span>
         )}
         {section.placeholder && (
-          <p className="text-xs text-gray-500 mt-1 truncate">
+          <p className="text-xs text-foreground/70 mt-1 truncate">
             {section.placeholder.substring(0, 100)}...
           </p>
         )}
@@ -272,22 +272,22 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
           </div>
         )}
 
-        <div className="bg-gray-50 p-3 rounded-lg">
+        <div className="bg-muted p-3 rounded-lg">
           <div className="flex justify-between items-center text-sm">
-            <span className="text-gray-600">
+            <span className="text-foreground/80">
               Sections visibles: <strong>{visibleCount}</strong> sur <strong>{totalCount}</strong>
             </span>
-            <span className="text-gray-600">
+            <span className="text-foreground/80">
               Sections par défaut: <strong>{sections.filter(section => section.isDefault).length}</strong>
             </span>
           </div>
         </div>
 
         <div className="space-y-3">
-          <h4 className="text-sm font-medium text-gray-900">Sections de la fiche projet</h4>
-          
+          <h4 className="text-sm font-medium text-foreground">Sections de la fiche projet</h4>
+
           {sections.length === 0 ? (
-            <p className="text-sm text-gray-500 italic text-center py-4">
+            <p className="text-sm text-foreground/70 italic text-center py-4">
               Aucune section dans cette fiche projet
             </p>
           ) : (
@@ -319,8 +319,8 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
         </div>
 
         {editingSection && (
-          <div className="border-t border-gray-200 pt-4">
-            <h4 className="text-sm font-medium text-gray-900 mb-3">Éditer la section</h4>
+          <div className="border-t border-muted pt-4">
+            <h4 className="text-sm font-medium text-foreground mb-3">Éditer la section</h4>
             <div className="space-y-3">
               <Input
                 label="Titre de la section"
@@ -368,8 +368,8 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
         )}
 
         {!isDisabled && !editingSection && (
-          <div className="border-t border-gray-200 pt-4">
-            <h4 className="text-sm font-medium text-gray-900 mb-3">Ajouter une nouvelle section</h4>
+          <div className="border-t border-muted pt-4">
+            <h4 className="text-sm font-medium text-foreground mb-3">Ajouter une nouvelle section</h4>
             <div className="space-y-3">
               <Input
                 label="Titre de la section"
@@ -409,7 +409,7 @@ const SectionEditorModal: React.FC<SectionEditorModalProps> = ({
           </div>
         )}
 
-        <div className="flex justify-end pt-4 border-t border-gray-200">
+        <div className="flex justify-end pt-4 border-t border-muted">
           <Button
             variant="secondary"
             onClick={onClose}

--- a/src/components/Project/StakeholderFormModal.tsx
+++ b/src/components/Project/StakeholderFormModal.tsx
@@ -116,8 +116,8 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
     <Modal isOpen={isOpen} onClose={handleClose} title={title}>
       <div className="space-y-6">
         {/* Informations personnelles */}
-        <div className="bg-gray-50 p-4 rounded-lg">
-          <h4 className="text-sm font-medium text-gray-900 mb-4">Informations personnelles</h4>
+        <div className="bg-muted p-4 rounded-lg">
+          <h4 className="text-sm font-medium text-foreground mb-4">Informations personnelles</h4>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <Input
               label="Prénom *"
@@ -173,8 +173,8 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
         </div>
 
         {/* Rôle et engagement */}
-        <div className="bg-gray-50 p-4 rounded-lg">
-          <h4 className="text-sm font-medium text-gray-900 mb-4">Rôle et engagement</h4>
+        <div className="bg-muted p-4 rounded-lg">
+          <h4 className="text-sm font-medium text-foreground mb-4">Rôle et engagement</h4>
           <div className="space-y-4">
             <Input
               label="Rôle sur le projet *"
@@ -206,8 +206,8 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
         </div>
 
         {/* Participation aux phases */}
-        <div className="bg-gray-50 p-4 rounded-lg">
-          <h4 className="text-sm font-medium text-gray-900 mb-4">Doit valider les phases :</h4>
+        <div className="bg-muted p-4 rounded-lg">
+          <h4 className="text-sm font-medium text-foreground mb-4">Doit valider les phases :</h4>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <Checkbox
               label="Phase Opportunité"
@@ -231,7 +231,7 @@ const StakeholderFormModal: React.FC<StakeholderFormModalProps> = ({
         </div>
 
         {/* Actions */}
-        <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200">
+        <div className="flex justify-end space-x-3 pt-4 border-t border-muted">
           <Button
             variant="secondary"
             onClick={handleClose}

--- a/src/components/Project/StakeholderTable.tsx
+++ b/src/components/Project/StakeholderTable.tsx
@@ -62,7 +62,7 @@ const StakeholderTable: React.FC<StakeholderTableProps> = ({
   return (
     <div className="space-y-4">
       <div className="flex justify-between items-center">
-        <h3 className="text-lg font-medium text-gray-900">Parties prenantes</h3>
+        <h3 className="text-lg font-medium text-foreground">Parties prenantes</h3>
         <Button
           variant="primary"
           size="sm"
@@ -74,74 +74,74 @@ const StakeholderTable: React.FC<StakeholderTableProps> = ({
       </div>
 
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-muted">
+          <thead className="bg-muted">
             <tr>
-              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Prénom
               </th>
-              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Nom
               </th>
-              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Rôle sur le projet
               </th>
-              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Email
               </th>
-              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Société
               </th>
-              <th rowSpan={2} className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-center text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Externe
               </th>
-              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-left text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Niveau d'engagement
               </th>
-              <th colSpan={3} className="px-4 py-2 text-center text-xs font-medium text-gray-900 uppercase tracking-wider border-b border-gray-300">
+              <th colSpan={3} className="px-4 py-2 text-center text-xs font-medium text-foreground uppercase tracking-wider border-b border-muted">
                 Doit valider les phases
               </th>
-              <th rowSpan={2} className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th rowSpan={2} className="px-4 py-3 text-center text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Actions
               </th>
             </tr>
             <tr>
-              <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-2 text-center text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Fiche projet initiale
               </th>
-              <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-2 text-center text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Options de périmètre
               </th>
-              <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-2 text-center text-xs font-medium text-foreground/70 uppercase tracking-wider">
                 Périmètre final
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-card divide-y divide-muted">
             {stakeholders.map((stakeholder) => (
-              <tr key={stakeholder.id} className="hover:bg-gray-50">
+              <tr key={stakeholder.id} className="hover:bg-muted">
                 <td className="px-4 py-4">
-                  <div className="text-sm font-medium text-gray-900">
+                  <div className="text-sm font-medium text-foreground">
                     {stakeholder.firstName}
                   </div>
                 </td>
                 <td className="px-4 py-4">
-                  <div className="text-sm font-medium text-gray-900">
+                  <div className="text-sm font-medium text-foreground">
                     {stakeholder.lastName}
                   </div>
                 </td>
                 <td className="px-4 py-4">
-                  <div className="text-sm text-gray-900 truncate max-w-[150px]" title={stakeholder.role}>
+                  <div className="text-sm text-foreground truncate max-w-[150px]" title={stakeholder.role}>
                     {stakeholder.role}
                   </div>
                 </td>
                 <td className="px-4 py-4">
-                  <div className="text-sm text-gray-500 truncate max-w-[120px]" title={stakeholder.email}>
+                  <div className="text-sm text-foreground/70 truncate max-w-[120px]" title={stakeholder.email}>
                     {stakeholder.email}
                   </div>
                 </td>
                 <td className="px-4 py-4">
-                  <div className="text-sm text-gray-900 truncate max-w-[100px]" title={stakeholder.company}>
+                  <div className="text-sm text-foreground truncate max-w-[100px]" title={stakeholder.company}>
                     {stakeholder.company}
                   </div>
                 </td>
@@ -151,11 +151,11 @@ const StakeholderTable: React.FC<StakeholderTableProps> = ({
                       ✓
                     </span>
                   ) : (
-                    <span className="text-gray-400">—</span>
+                    <span className="text-muted">—</span>
                   )}
                 </td>
                 <td className="px-4 py-4">
-                  <div className="text-sm text-gray-500">
+                  <div className="text-sm text-foreground/70">
                     {stakeholder.engagementLevel && (
                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                         {stakeholder.engagementLevel}

--- a/src/components/UI/AlertDialog.tsx
+++ b/src/components/UI/AlertDialog.tsx
@@ -45,12 +45,12 @@ const AlertDialog: React.FC = () => {
         <div className={`mx-auto flex items-center justify-center h-12 w-12 rounded-full ${getIconBgColor()}`}>
           {getIcon()}
         </div>
-        
+
         <div className="space-y-2">
-          <h3 className="text-lg font-medium text-gray-900">
+          <h3 className="text-lg font-medium text-foreground">
             {title}
           </h3>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-foreground/80">
             {message}
           </p>
         </div>

--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -16,11 +16,11 @@ const Button: React.FC<ButtonProps> = ({
   className = '', 
   ...props 
 }) => {
-  const baseClasses = 'inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+  const baseClasses = 'inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background';
 
   const variantClasses = {
     primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
-    secondary: 'bg-white text-text hover:bg-gray-50 focus:ring-gray-300',
+    secondary: 'bg-card text-foreground hover:bg-muted focus:ring-muted',
   };
   
   const sizeClasses = {

--- a/src/components/UI/Checkbox.tsx
+++ b/src/components/UI/Checkbox.tsx
@@ -30,7 +30,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
             w-5 h-5 border-2 rounded cursor-pointer transition-colors duration-200
             ${checked
               ? 'bg-primary border-primary'
-              : 'bg-white border-gray-300 hover:border-gray-400'
+              : 'bg-card border-muted hover:border-foreground/50'
             }
             ${disabled
               ? 'cursor-not-allowed opacity-50'
@@ -48,12 +48,12 @@ const Checkbox: React.FC<CheckboxProps> = ({
       {(label || description) && (
         <div className="flex-1">
           {label && (
-            <label className={`block text-sm font-medium cursor-pointer ${disabled ? 'text-gray-400 cursor-not-allowed' : 'text-text'}`}>
+            <label className={`block text-sm font-medium cursor-pointer ${disabled ? 'text-muted cursor-not-allowed' : 'text-foreground'}`}>
               {label}
             </label>
           )}
           {description && (
-            <p className={`text-sm ${disabled ? 'text-gray-400' : 'text-gray-500'}`}>{description}</p>
+            <p className={`text-sm ${disabled ? 'text-muted' : 'text-foreground/70'}`}>{description}</p>
           )}
         </div>
       )}

--- a/src/components/UI/Input.tsx
+++ b/src/components/UI/Input.tsx
@@ -14,14 +14,14 @@ const Input: React.FC<InputProps> = ({
   return (
     <div className="space-y-1">
       {label && (
-        <label className="block text-sm font-medium text-text">
+        <label className="block text-sm font-medium text-foreground">
           {label}
         </label>
       )}
       <input
         className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm
-          placeholder-gray-400 text-text focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+          block w-full rounded-md border border-muted bg-card px-3 py-2 text-sm shadow-sm
+          placeholder-muted/80 text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent
           ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
           ${className}
         `}

--- a/src/components/UI/Modal.tsx
+++ b/src/components/UI/Modal.tsx
@@ -17,15 +17,15 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, modalCl
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen text-center sm:block">
         <div className="fixed inset-0 bg-black/50" onClick={onClose} />
-        
+
         <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
           &#8203;
         </span>
-        
-        <div className={`inline-block align-middle bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:align-middle sm:w-full ${modalClassName || 'sm:max-w-lg'}`}>
-          <div className="bg-white px-4 py-3 sm:px-4 sm:py-3 flex flex-col h-full">
+
+        <div className={`inline-block align-middle bg-card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:align-middle sm:w-full ${modalClassName || 'sm:max-w-lg'}`}>
+          <div className="bg-card px-4 py-3 sm:px-4 sm:py-3 flex flex-col h-full text-foreground">
             <div className="flex items-center justify-between mb-4 flex-shrink-0">
-              <h3 className="text-lg font-medium text-text">
+              <h3 className="text-lg font-medium">
                 {title}
               </h3>
               <Button
@@ -33,7 +33,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, modalCl
                 size="sm"
                 onClick={onClose}
                 icon={X}
-                className="p-1 border-0 bg-transparent text-gray-400 hover:text-gray-600"
+                className="p-1 border-0 bg-transparent text-muted hover:text-foreground"
               />
             </div>
             <div className="flex-grow overflow-y-auto">

--- a/src/components/UI/RichTextEditor.tsx
+++ b/src/components/UI/RichTextEditor.tsx
@@ -43,7 +43,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
   return (
     <div className={`space-y-1 ${className}`}>
       {label && (
-        <label className="flex items-center text-sm font-medium text-gray-700">
+        <label className="flex items-center text-sm font-medium text-foreground">
           <span>{label}</span>
           {showPlaceholderAsTooltip && placeholder && (
             <TooltipIcon content={placeholder} />
@@ -51,7 +51,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
         </label>
       )}
       <div className={`
-        ${error ? 'border-red-300' : 'border-gray-300'}
+        ${error ? 'border-red-300' : 'border-muted'}
         rounded-md quill-editor-wrapper ${readOnly ? 'read-only' : ''}
       `}>
         <ReactQuill

--- a/src/components/UI/Select.tsx
+++ b/src/components/UI/Select.tsx
@@ -16,14 +16,14 @@ const Select: React.FC<SelectProps> = ({
   return (
     <div className="space-y-1">
       {label && (
-        <label className="block text-sm font-medium text-text">
+        <label className="block text-sm font-medium text-foreground">
           {label}
         </label>
       )}
       <select
         className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm
-          text-text focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+          block w-full rounded-md border border-muted bg-card px-3 py-2 text-sm shadow-sm
+          text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent
           ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
           ${className}
         `}

--- a/src/components/UI/Tabs.tsx
+++ b/src/components/UI/Tabs.tsx
@@ -18,7 +18,7 @@ interface TabsProps {
 const Tabs: React.FC<TabsProps> = ({ tabs, activeTab, onTabChange, activeTabColorClass = 'border-primary text-primary', className = '' }) => {
   return (
     <div className={className}>
-      <div className="border-b border-gray-200">
+      <div className="border-b border-muted">
         <nav className="-mb-px flex space-x-6">
           {tabs.map((tab) => (
             <Button
@@ -30,7 +30,7 @@ const Tabs: React.FC<TabsProps> = ({ tabs, activeTab, onTabChange, activeTabColo
                 border-0 border-b-2 rounded-none bg-transparent whitespace-nowrap
                 ${activeTab === tab.id
                   ? `${activeTabColorClass}`
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  : 'border-transparent text-foreground/70 hover:text-foreground hover:border-muted'
                 }
               `}
             >

--- a/src/components/UI/Textarea.tsx
+++ b/src/components/UI/Textarea.tsx
@@ -14,14 +14,14 @@ const Textarea: React.FC<TextareaProps> = ({
   return (
     <div className="space-y-1">
       {label && (
-        <label className="block text-sm font-medium text-text">
+        <label className="block text-sm font-medium text-foreground">
           {label}
         </label>
       )}
       <textarea
         className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm
-          placeholder-gray-400 text-text focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+          block w-full rounded-md border border-muted bg-card px-3 py-2 text-sm shadow-sm
+          placeholder-muted/80 text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent
           ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
           ${className}
         `}

--- a/src/components/UI/TooltipIcon.tsx
+++ b/src/components/UI/TooltipIcon.tsx
@@ -17,7 +17,7 @@ const TooltipIcon: React.FC<TooltipIconProps> = ({ content, className = '' }) =>
         variant="secondary"
         size="sm"
         icon={HelpCircle}
-        className="ml-2 p-1 border-0 bg-transparent text-gray-400 hover:text-gray-600"
+        className="ml-2 p-1 border-0 bg-transparent text-muted hover:text-foreground"
         onMouseEnter={() => setIsVisible(true)}
         onMouseLeave={() => setIsVisible(false)}
         onFocus={() => setIsVisible(true)}
@@ -25,8 +25,8 @@ const TooltipIcon: React.FC<TooltipIconProps> = ({ content, className = '' }) =>
       />
       
       {isVisible && (
-        <div className="absolute left-0 top-6 z-50 w-144 p-3 bg-gray-800 text-white text-xs rounded-lg shadow-lg">
-          <div className="absolute -top-1 left-2 w-2 h-2 bg-gray-800 transform rotate-45"></div>
+        <div className="absolute left-0 top-6 z-50 w-144 p-3 bg-foreground text-background text-xs rounded-lg shadow-lg">
+          <div className="absolute -top-1 left-2 w-2 h-2 bg-foreground transform rotate-45"></div>
           <div className="whitespace-pre-wrap">{content}</div>
         </div>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -41,22 +41,22 @@
 /* RichTextEditor custom styles */
 .quill-editor-wrapper .ql-editor {
   min-height: 120px;
-  background-color: #ffffff;
+  background-color: hsl(var(--card));
 }
 
 .quill-editor-wrapper .ql-toolbar {
-  background-color: #f3f4f6;
-  border-bottom: 1px solid #e5e7eb;
+  background-color: hsl(var(--muted));
+  border-bottom: 1px solid hsl(var(--muted));
 }
 
 /* Read-only editor styles */
 .quill-editor-wrapper .ql-container.ql-disabled {
-  background-color: #f9fafb;
-  border-color: #e5e7eb;
+  background-color: hsl(var(--muted));
+  border-color: hsl(var(--muted));
 }
 
 .quill-editor-wrapper .ql-editor.ql-disabled {
-  color: #6b7280;
+  color: hsl(var(--foreground) / 0.6);
 }
 
 .quill-editor-wrapper.read-only .ql-toolbar {
@@ -64,7 +64,7 @@
 }
 
 .quill-editor-wrapper.read-only .ql-container {
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid hsl(var(--muted));
 }
 
 .is-exporting-pdf .ql-toolbar {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -172,7 +172,7 @@ const Dashboard: React.FC = () => {
       final: 'bg-green-100 text-green-800'
     };
 
-    return colors[project.currentPhase] || 'bg-gray-100 text-gray-800';
+    return colors[project.currentPhase] || 'bg-muted text-foreground';
   };
 
   interface StakeholderInfo {
@@ -228,7 +228,7 @@ const Dashboard: React.FC = () => {
               <h3 className="text-lg font-semibold text-foreground truncate">
                 {project.name}
               </h3>
-              <p className="mt-1 text-sm text-gray-700 truncate">
+              <p className="mt-1 text-sm text-foreground/80 truncate">
                 {project.description}
               </p>
             </div>
@@ -255,7 +255,7 @@ const Dashboard: React.FC = () => {
           </div>
 
           <div className="mt-auto space-y-3">
-            <div className="flex items-center justify-between text-sm text-gray-700">
+            <div className="flex items-center justify-between text-sm text-foreground/80">
               <div className="flex items-center">
                 <Calendar className="h-4 w-4 mr-1" />
                 {formatDate(project.createdAt)}
@@ -273,14 +273,14 @@ const Dashboard: React.FC = () => {
               </span>
             </div>
             <div className="flex items-center space-x-2">
-              <BarChart3 className="h-4 w-4 text-gray-700" />
+              <BarChart3 className="h-4 w-4 text-foreground/80" />
               <div className="w-full bg-muted rounded-full h-1.5">
                 <div
                   className="bg-primary h-1.5 rounded-full transition-all duration-300"
                   style={{ width: `${progress.percentage}%` }}
                 />
               </div>
-              <span className="text-xs text-gray-700 font-medium min-w-[2rem]">
+              <span className="text-xs text-foreground/80 font-medium min-w-[2rem]">
                 {progress.completed}/{progress.total}
               </span>
             </div>
@@ -291,11 +291,11 @@ const Dashboard: React.FC = () => {
   };
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-foreground">
       <div className="flex justify-between items-center mb-8">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Mes projets</h1>
-          <p className="mt-2 text-gray-700">
+          <p className="mt-2 text-foreground/80">
             Formalisez vos projets pas à pas, avant démarrage
           </p>
         </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -55,14 +55,14 @@ const Login: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
-      <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-xl shadow-lg">
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="max-w-md w-full space-y-8 p-8 bg-card rounded-xl shadow-lg text-foreground">
         <div className="text-center">
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-lg flex items-center justify-center">
             <LogIn className="h-6 w-6 text-white" />
           </div>
-          <h2 className="mt-6 text-3xl font-bold text-gray-900">Scopilot</h2>
-          <p className="mt-2 text-sm text-gray-600 italic">Cadrez. Engagez. Avancez.</p>
+          <h2 className="mt-6 text-3xl font-bold text-foreground">Scopilot</h2>
+          <p className="mt-2 text-sm text-foreground/80 italic">Cadrez. Engagez. Avancez.</p>
         </div>
         
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -38,7 +38,7 @@ const Project: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">Projet non trouvé</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-4">Projet non trouvé</h1>
           <Button
             variant="primary"
             icon={ArrowLeft}
@@ -136,10 +136,10 @@ const Project: React.FC = () => {
                   className={`
                     flex items-center justify-center px-5 py-2 rounded-xl text-base font-semibold transition-all duration-300 transform hover:scale-105 w-full
                     ${isActive
-                      ? `bg-white text-${phase.color}-800 border-b-4 border-${phase.color}-600`
+                      ? `bg-card text-${phase.color}-800 border-b-4 border-${phase.color}-600`
                       : canAccess
-                        ? `bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 shadow-sm`
-                        : `bg-gray-100 text-gray-400 border-2 border-gray-200 cursor-not-allowed opacity-60`
+                        ? `bg-card text-foreground border border-muted hover:bg-muted hover:border-foreground/50 shadow-sm`
+                        : `bg-muted text-foreground/50 border-2 border-muted cursor-not-allowed opacity-60`
                     }
                     ${status === 'completed' ? `ring-3 ring-green-500 ring-opacity-60 shadow-lg` : ''}
                   `}
@@ -150,7 +150,7 @@ const Project: React.FC = () => {
                       ? 'bg-green-500 text-white' 
                       : isActive 
                         ? `bg-${phase.color}-100 border-2 border-${phase.color}-800 text-${phase.color}-800`
-                        : 'bg-gray-300 text-gray-600'
+                        : 'bg-muted text-foreground/60'
                     }
                   `}>
                     {status === 'completed' ? '✓' : index + 1}
@@ -158,7 +158,7 @@ const Project: React.FC = () => {
                   <span className="whitespace-nowrap">{phase.label}</span>
                 </Button>
                 {index < phases.length - 1 && (
-                  <ChevronRight className="h-6 w-6 text-gray-400 mx-2" />
+                  <ChevronRight className="h-6 w-6 text-muted mx-2" />
                 )}
               </React.Fragment>
             );

--- a/src/pages/phases/FinalPhase.tsx
+++ b/src/pages/phases/FinalPhase.tsx
@@ -159,7 +159,7 @@ const FinalPhase: React.FC<FinalPhaseProps> = ({ project }) => {
                       style={{ width: `${approvalRate}%` }}
                     />
                   </div>
-                  <span className="text-sm text-gray-600 font-medium min-w-[3rem]">
+                  <span className="text-sm text-foreground/80 font-medium min-w-[3rem]">
                     {approvedCount}/{mandatoryStakeholders.length}
                   </span>
                 </div>
@@ -292,7 +292,7 @@ const FinalPhase: React.FC<FinalPhaseProps> = ({ project }) => {
   ];
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 text-foreground">
       <Tabs
         tabs={tabs}
         activeTab={activeTab}

--- a/src/pages/phases/InitialPhase.tsx
+++ b/src/pages/phases/InitialPhase.tsx
@@ -115,7 +115,7 @@ const InitialPhase: React.FC<InitialPhaseProps> = ({ project }) => {
                       style={{ width: `${approvalRate}%` }}
                     />
                   </div>
-                  <span className="text-sm text-gray-600 font-medium min-w-[3rem]">
+                  <span className="text-sm text-foreground/80 font-medium min-w-[3rem]">
                     {approvedCount}/{mandatoryStakeholders.length}
                   </span>
                 </div>
@@ -263,7 +263,7 @@ const InitialPhase: React.FC<InitialPhaseProps> = ({ project }) => {
   ];
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 text-foreground">
       <Tabs
         tabs={tabs}
         activeTab={activeTab}

--- a/src/pages/phases/OptionsPhase.tsx
+++ b/src/pages/phases/OptionsPhase.tsx
@@ -226,7 +226,7 @@ const OptionsPhase: React.FC<OptionsPhaseProps> = ({ project }) => {
                     />
                   </div>
                   <span className="text-sm text-muted font-medium min-w-[3rem]">
-                  <span className="text-sm text-gray-600 font-medium min-w-[3rem]">
+                  <span className="text-sm text-foreground/80 font-medium min-w-[3rem]">
                     {approvedCount}/{mandatoryStakeholders.length}
                   </span>
                   </span>
@@ -462,7 +462,7 @@ const OptionsPhase: React.FC<OptionsPhaseProps> = ({ project }) => {
   ];
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 text-foreground">
       <Tabs
         tabs={tabs}
         activeTab={activeTab}


### PR DESCRIPTION
## Summary
- add light/dark mode toggle in header with persistence
- update UI components to use theme variables
- ensure pages render using shared theme classes

## Testing
- `npm run lint` (fails: ESLint configuration missing)
- `npm run build` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68ab15afe4248327b3f65266d4e4ca1a