### PR TITLE
feat: integrate daisyui and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="fr" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@typescript-eslint/parser": "^6.10.0",
         "@vitejs/plugin-react": "^4.1.1",
         "autoprefixer": "^10.4.16",
-        "daisyui": "^4.10.1",
         "eslint": "^8.53.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.4",
@@ -2708,17 +2707,6 @@
         "utrie": "^1.0.2"
       }
     },
-    "node_modules/css-selector-tokenizer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
-      "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2738,36 +2726,6 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/culori": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/culori/-/culori-3.3.0.tgz",
-      "integrity": "sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/daisyui": {
-      "version": "4.12.24",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-4.12.24.tgz",
-      "integrity": "sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.8",
-        "culori": "^3",
-        "picocolors": "^1",
-        "postcss-js": "^4"
-      },
-      "engines": {
-        "node": ">=16.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/daisyui"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -3284,13 +3242,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "daisyui": "^4.12.10",
         "firebase": "^12.1.0",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.1",
@@ -2467,7 +2468,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2707,11 +2707,20 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/css-selector-tokenizer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
+      "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "fastparse": "^1.1.2"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -2726,6 +2735,34 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/culori": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/culori/-/culori-3.3.0.tgz",
+      "integrity": "sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "4.12.24",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-4.12.24.tgz",
+      "integrity": "sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-selector-tokenizer": "^0.8",
+        "culori": "^3",
+        "picocolors": "^1",
+        "postcss-js": "^4"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/daisyui"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -3243,6 +3280,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -4247,7 +4290,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4509,7 +4551,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -4549,7 +4590,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4596,7 +4636,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -5220,7 +5259,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^18.2.0",
     "react-quill": "^2.0.0",
     "react-router-dom": "^6.20.1",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "daisyui": "^4.12.10"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -5,6 +5,7 @@ import { useAlertStore } from '../../store/useAlertStore';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { LogOut, Home, Folder } from 'lucide-react';
 import Button from '../UI/Button';
+import ThemeToggle from '../UI/ThemeToggle';
 
 const Header: React.FC = () => {
   const { user, logout } = useAuthStore();
@@ -29,56 +30,48 @@ const Header: React.FC = () => {
   const isOnProject = location.pathname.startsWith('/project/');
 
   return (
-    <header className="fixed top-0 w-full z-50 bg-primary text-background shadow-sm border-b border-primary">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
-          <div className="flex items-center space-x-4">
-            <div className="flex items-center space-x-2">
-              <div className="h-8 w-8 bg-accent rounded-lg flex items-center justify-center">
-                <Folder className="h-4 w-4 text-background" />
-              </div>
-              <div>
-                <h1 className="text-xl font-bold">Scopilot</h1>
-                <p className="text-xs italic text-background/80">Cadrez. Engagez. Avancez.</p>
-              </div>
-            </div>
-
-            {!isOnDashboard && (
-              <Button
-                variant="secondary"
-                size="sm"
-                icon={Home}
-                onClick={() => navigate('/dashboard')}
-              >
-                Accueil
-              </Button>
-            )}
-
-            {isOnProject && currentProject && (
-              <>
-                <div className="h-6 border-l border-background mx-4" />
-                <div className="flex-1 text-center">
-                  <span className="font-bold text-2xl">{currentProject.name}</span>
-                </div>
-              </>
-            )}
+    <header className="navbar bg-base-100 shadow-sm fixed top-0 w-full z-50">
+      <div className="flex-1">
+        <div className="flex items-center space-x-2">
+          <div className="h-8 w-8 bg-primary rounded-lg flex items-center justify-center text-primary-content">
+            <Folder className="h-4 w-4" />
           </div>
-
-          <div className="flex items-center space-x-4">
-            <div className="h-6 border-l border-background mx-4" />
-            <span className="text-sm text-background/80">
-              Connecté en tant que <span className="font-medium">{user?.username}</span>
-            </span>
-            <Button
-              variant="secondary"
-              size="sm"
-              icon={LogOut}
-              onClick={handleLogout}
-            >
-              Déconnexion
-            </Button>
+          <div>
+            <h1 className="text-xl font-bold">Scopilot</h1>
+            <p className="text-xs italic">Cadrez. Engagez. Avancez.</p>
           </div>
         </div>
+
+        {!isOnDashboard && (
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={Home}
+            onClick={() => navigate('/dashboard')}
+            className="ml-4"
+          >
+            Accueil
+          </Button>
+        )}
+
+        {isOnProject && currentProject && (
+          <span className="ml-4 font-bold text-2xl">{currentProject.name}</span>
+        )}
+      </div>
+
+      <div className="flex-none gap-2">
+        <span className="text-sm mr-2">
+          Connecté en tant que <span className="font-medium">{user?.username}</span>
+        </span>
+        <ThemeToggle />
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={LogOut}
+          onClick={handleLogout}
+        >
+          Déconnexion
+        </Button>
       </div>
     </header>
   );

--- a/src/components/UI/AlertDialog.tsx
+++ b/src/components/UI/AlertDialog.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { CheckCircle, AlertCircle, Info } from 'lucide-react';
 import Modal from './Modal';
 import Button from './Button';
 import { useAlertStore } from '../../store/useAlertStore';
@@ -14,24 +13,14 @@ const AlertDialog: React.FC = () => {
     }
   };
 
-  const getIcon = () => {
+  const getAlertClass = () => {
     if (title.toLowerCase().includes('succès') || title.toLowerCase().includes('réussi')) {
-      return <CheckCircle className="h-6 w-6 text-green-600" />;
+      return 'alert-success';
     }
     if (title.toLowerCase().includes('erreur')) {
-      return <AlertCircle className="h-6 w-6 text-red-600" />;
+      return 'alert-error';
     }
-    return <Info className="h-6 w-6 text-blue-600" />;
-  };
-
-  const getIconBgColor = () => {
-    if (title.toLowerCase().includes('succès') || title.toLowerCase().includes('réussi')) {
-      return 'bg-green-100';
-    }
-    if (title.toLowerCase().includes('erreur')) {
-      return 'bg-red-100';
-    }
-    return 'bg-blue-100';
+    return 'alert-info';
   };
 
   return (
@@ -41,26 +30,13 @@ const AlertDialog: React.FC = () => {
       title=""
       modalClassName="sm:max-w-md"
     >
-      <div className="text-center space-y-4">
-        <div className={`mx-auto flex items-center justify-center h-12 w-12 rounded-full ${getIconBgColor()}`}>
-          {getIcon()}
+      <div className={`alert ${getAlertClass()} flex-col text-center`}>
+        <div>
+          <span className="font-bold">{title}</span>
+          <p>{message}</p>
         </div>
-        
-        <div className="space-y-2">
-          <h3 className="text-lg font-medium text-gray-900">
-            {title}
-          </h3>
-          <p className="text-sm text-gray-600">
-            {message}
-          </p>
-        </div>
-
-        <div className="pt-4">
-          <Button
-            variant="primary"
-            onClick={handleConfirm}
-            className="w-full"
-          >
+        <div className="mt-4">
+          <Button variant="primary" onClick={handleConfirm} className="w-full">
             OK
           </Button>
         </div>

--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -2,39 +2,35 @@ import React from 'react';
 import { DivideIcon as LucideIcon } from 'lucide-react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary';
+  variant?: 'primary' | 'secondary' | 'error';
   size?: 'sm' | 'md' | 'lg';
   icon?: LucideIcon;
   children?: React.ReactNode;
 }
 
-const Button: React.FC<ButtonProps> = ({ 
-  variant = 'primary', 
-  size = 'md', 
-  icon: Icon, 
-  children, 
-  className = '', 
-  ...props 
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  icon: Icon,
+  children,
+  className = '',
+  ...props
 }) => {
-  const baseClasses = 'inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
-
   const variantClasses = {
-    primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
-    secondary: 'bg-white text-text hover:bg-gray-50 focus:ring-gray-300',
-  };
-  
-  const sizeClasses = {
-    sm: 'px-3 py-1.5 text-sm',
-    md: 'px-4 py-2 text-sm',
-    lg: 'px-6 py-3 text-base'
+    primary: 'btn-primary',
+    secondary: 'btn-secondary',
+    error: 'btn-error',
   };
 
-  const classes = [
-    baseClasses,
-    variantClasses[variant],
-    sizeClasses[size],
-    className,
-  ].join(' ').trim();
+  const sizeClasses = {
+    sm: 'btn-sm',
+    md: '',
+    lg: 'btn-lg',
+  };
+
+  const classes = ['btn', variantClasses[variant], sizeClasses[size], className]
+    .join(' ')
+    .trim();
 
   return (
     <button className={classes} {...props}>

--- a/src/components/UI/Checkbox.tsx
+++ b/src/components/UI/Checkbox.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Check } from 'lucide-react';
 
 interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
   label?: string;
@@ -7,56 +6,27 @@ interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>
   disabled?: boolean;
 }
 
-const Checkbox: React.FC<CheckboxProps> = ({ 
-  label, 
+const Checkbox: React.FC<CheckboxProps> = ({
+  label,
   description,
-  className = '', 
+  className = '',
   checked,
   disabled = false,
-  ...props 
+  ...props
 }) => {
   return (
-    <div className="flex items-start space-x-3">
-      <div className="relative flex items-center">
+    <div className="form-control">
+      <label className="label cursor-pointer">
         <input
           type="checkbox"
-          className="sr-only"
+          className={`checkbox ${className}`}
           checked={checked}
           disabled={disabled}
           {...props}
         />
-        <div
-          className={`
-            w-5 h-5 border-2 rounded cursor-pointer transition-colors duration-200
-            ${checked
-              ? 'bg-primary border-primary'
-              : 'bg-white border-gray-300 hover:border-gray-400'
-            }
-            ${disabled
-              ? 'cursor-not-allowed opacity-50'
-              : 'cursor-pointer'
-            }
-            ${className}
-          `}
-          onClick={() => !disabled && props.onChange?.({ target: { checked: !checked } } as any)}
-        >
-          {checked && (
-            <Check className="w-3 h-3 text-white absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
-          )}
-        </div>
-      </div>
-      {(label || description) && (
-        <div className="flex-1">
-          {label && (
-            <label className={`block text-sm font-medium cursor-pointer ${disabled ? 'text-gray-400 cursor-not-allowed' : 'text-text'}`}>
-              {label}
-            </label>
-          )}
-          {description && (
-            <p className={`text-sm ${disabled ? 'text-gray-400' : 'text-gray-500'}`}>{description}</p>
-          )}
-        </div>
-      )}
+        {label && <span className="label-text ml-2">{label}</span>}
+      </label>
+      {description && <span className="label-text-alt ml-8">{description}</span>}
     </div>
   );
 };

--- a/src/components/UI/Input.tsx
+++ b/src/components/UI/Input.tsx
@@ -5,30 +5,23 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
 }
 
-const Input: React.FC<InputProps> = ({ 
-  label, 
-  error, 
-  className = '', 
-  ...props 
+const Input: React.FC<InputProps> = ({
+  label,
+  error,
+  className = '',
+  ...props
 }) => {
   return (
-    <div className="space-y-1">
-      {label && (
-        <label className="block text-sm font-medium text-text">
-          {label}
-        </label>
-      )}
+    <div className="form-control w-full">
+      {label && <label className="label"><span className="label-text">{label}</span></label>}
       <input
-        className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm
-          placeholder-gray-400 text-text focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
-          ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
-          ${className}
-        `}
+        className={`input input-bordered w-full ${className}`}
         {...props}
       />
       {error && (
-        <p className="text-sm text-red-600">{error}</p>
+        <label className="label">
+          <span className="label-text-alt text-error">{error}</span>
+        </label>
       )}
     </div>
   );

--- a/src/components/UI/Modal.tsx
+++ b/src/components/UI/Modal.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { X } from 'lucide-react';
 import Button from './Button';
 
 interface ModalProps {
@@ -11,37 +10,18 @@ interface ModalProps {
 }
 
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, modalClassName }) => {
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex items-center justify-center min-h-screen text-center sm:block">
-        <div className="fixed inset-0 bg-black/50" onClick={onClose} />
-        
-        <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
-          &#8203;
-        </span>
-        
-        <div className={`inline-block align-middle bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:align-middle sm:w-full ${modalClassName || 'sm:max-w-lg'}`}>
-          <div className="bg-white px-4 py-3 sm:px-4 sm:py-3 flex flex-col h-full">
-            <div className="flex items-center justify-between mb-4 flex-shrink-0">
-              <h3 className="text-lg font-medium text-text">
-                {title}
-              </h3>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={onClose}
-                icon={X}
-                className="p-1 border-0 bg-transparent text-gray-400 hover:text-gray-600"
-              />
-            </div>
-            <div className="flex-grow overflow-y-auto">
-              {children}
-            </div>
-          </div>
+    <div className={`modal ${isOpen ? 'modal-open' : ''}`}>
+      <div className={`modal-box ${modalClassName || ''}`}>
+        <h3 className="font-bold text-lg">{title}</h3>
+        <div className="py-4">{children}</div>
+        <div className="modal-action">
+          <Button variant="secondary" onClick={onClose}>
+            Fermer
+          </Button>
         </div>
       </div>
+      <div className="modal-backdrop" onClick={onClose} />
     </div>
   );
 };

--- a/src/components/UI/Select.tsx
+++ b/src/components/UI/Select.tsx
@@ -14,25 +14,15 @@ const Select: React.FC<SelectProps> = ({
   ...props
 }) => {
   return (
-    <div className="space-y-1">
-      {label && (
-        <label className="block text-sm font-medium text-text">
-          {label}
-        </label>
-      )}
-      <select
-        className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm
-          text-text focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
-          ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
-          ${className}
-        `}
-        {...props}
-      >
+    <div className="form-control w-full">
+      {label && <label className="label"><span className="label-text">{label}</span></label>}
+      <select className={`select select-bordered w-full ${className}`} {...props}>
         {children}
       </select>
       {error && (
-        <p className="text-sm text-red-600">{error}</p>
+        <label className="label">
+          <span className="label-text-alt text-error">{error}</span>
+        </label>
       )}
     </div>
   );

--- a/src/components/UI/Tabs.tsx
+++ b/src/components/UI/Tabs.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Button from './Button';
 
 interface Tab {
   id: string;
@@ -11,33 +10,23 @@ interface TabsProps {
   tabs: Tab[];
   activeTab: string;
   onTabChange: (tabId: string) => void;
-  activeTabColorClass?: string;
   className?: string;
 }
 
-const Tabs: React.FC<TabsProps> = ({ tabs, activeTab, onTabChange, activeTabColorClass = 'border-primary text-primary', className = '' }) => {
+const Tabs: React.FC<TabsProps> = ({ tabs, activeTab, onTabChange, className = '' }) => {
   return (
     <div className={className}>
-      <div className="border-b border-gray-200">
-        <nav className="-mb-px flex space-x-6">
-          {tabs.map((tab) => (
-            <Button
-              key={tab.id}
-              onClick={() => onTabChange(tab.id)}
-              variant="secondary"
-              size="sm"
-              className={`
-                border-0 border-b-2 rounded-none bg-transparent whitespace-nowrap
-                ${activeTab === tab.id
-                  ? `${activeTabColorClass}`
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                }
-              `}
-            >
-              {tab.label}
-            </Button>
-          ))}
-        </nav>
+      <div role="tablist" className="tabs tabs-bordered">
+        {tabs.map((tab) => (
+          <a
+            key={tab.id}
+            role="tab"
+            className={`tab ${activeTab === tab.id ? 'tab-active' : ''}`}
+            onClick={() => onTabChange(tab.id)}
+          >
+            {tab.label}
+          </a>
+        ))}
       </div>
       <div className="mt-3">
         {tabs.find(tab => tab.id === activeTab)?.content}

--- a/src/components/UI/Textarea.tsx
+++ b/src/components/UI/Textarea.tsx
@@ -5,31 +5,24 @@ interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement
   error?: string;
 }
 
-const Textarea: React.FC<TextareaProps> = ({ 
-  label, 
-  error, 
-  className = '', 
-  ...props 
+const Textarea: React.FC<TextareaProps> = ({
+  label,
+  error,
+  className = '',
+  ...props
 }) => {
   return (
-    <div className="space-y-1">
-      {label && (
-        <label className="block text-sm font-medium text-text">
-          {label}
-        </label>
-      )}
+    <div className="form-control w-full">
+      {label && <label className="label"><span className="label-text">{label}</span></label>}
       <textarea
-        className={`
-          block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm
-          placeholder-gray-400 text-text focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
-          ${error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}
-          ${className}
-        `}
+        className={`textarea textarea-bordered w-full ${className}`}
         rows={4}
         {...props}
       />
       {error && (
-        <p className="text-sm text-red-600">{error}</p>
+        <label className="label">
+          <span className="label-text-alt text-error">{error}</span>
+        </label>
       )}
     </div>
   );

--- a/src/components/UI/ThemeToggle.tsx
+++ b/src/components/UI/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <button
+      className="btn btn-ghost btn-circle"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/UI/TooltipIcon.tsx
+++ b/src/components/UI/TooltipIcon.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { HelpCircle } from 'lucide-react';
 import Button from './Button';
 
@@ -8,28 +8,15 @@ interface TooltipIconProps {
 }
 
 const TooltipIcon: React.FC<TooltipIconProps> = ({ content, className = '' }) => {
-  const [isVisible, setIsVisible] = useState(false);
-
   return (
-    <div className={`relative inline-block ${className}`}>
+    <div className={`tooltip ${className}`} data-tip={content}>
       <Button
         type="button"
         variant="secondary"
         size="sm"
         icon={HelpCircle}
-        className="ml-2 p-1 border-0 bg-transparent text-gray-400 hover:text-gray-600"
-        onMouseEnter={() => setIsVisible(true)}
-        onMouseLeave={() => setIsVisible(false)}
-        onFocus={() => setIsVisible(true)}
-        onBlur={() => setIsVisible(false)}
+        className="ml-2 btn-circle btn-ghost"
       />
-      
-      {isVisible && (
-        <div className="absolute left-0 top-6 z-50 w-144 p-3 bg-gray-800 text-white text-xs rounded-lg shadow-lg">
-          <div className="absolute -top-1 left-2 w-2 h-2 bg-gray-800 transform rotate-45"></div>
-          <div className="whitespace-pre-wrap">{content}</div>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -3,38 +3,8 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    /* Minimal light palette */
-    --background: 0 0% 100%;
-    --foreground: 222 47% 11%;
-    --muted: 220 14% 96%;
-    --card: 0 0% 100%;
-    --accent: 215 89% 55%;
-    --accent-foreground: 0 0% 100%;
-  }
-
-  .dark {
-    /* Minimal dark palette */
-    --background: 222 47% 11%;
-    --foreground: 210 20% 98%;
-    --muted: 217 15% 28%;
-    --card: 222 47% 13%;
-    --accent: 215 89% 65%;
-    --accent-foreground: 0 0% 100%;
-  }
-
   html {
     font-family: 'Inter', system-ui, sans-serif;
-  }
-
-  body {
-    @apply bg-background text-foreground;
-  }
-}
-
-@layer components {
-  .card {
-    @apply bg-card text-foreground rounded-xl shadow-sm border border-muted;
   }
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -217,18 +217,18 @@ const Dashboard: React.FC = () => {
   const ProjectItem: React.FC<{ project: Project }> = ({ project }) => {
     const progress = calculateCombinedProgress(project);
 
-    return (
-      <li key={project.id} className="card hover:shadow-md transition-shadow">
-        <div
-          className="p-6 cursor-pointer flex flex-col h-full"
-          onClick={() => navigate(`/project/${project.id}`)}
-        >
-          <div className="flex items-start justify-between mb-4">
+      return (
+        <li key={project.id} className="card bg-base-100 hover:shadow-md transition-shadow">
+          <div
+            className="card-body p-6 cursor-pointer flex flex-col h-full"
+            onClick={() => navigate(`/project/${project.id}`)}
+          >
+            <div className="flex items-start justify-between mb-4">
             <div className="flex-1 min-w-0">
-              <h3 className="text-lg font-semibold text-foreground truncate">
+                <h3 className="card-title truncate">
                 {project.name}
               </h3>
-              <p className="mt-1 text-sm text-gray-700 truncate">
+                <p className="mt-1 text-sm text-base-content/70 truncate">
                 {project.description}
               </p>
             </div>
@@ -254,8 +254,8 @@ const Dashboard: React.FC = () => {
             </div>
           </div>
 
-          <div className="mt-auto space-y-3">
-            <div className="flex items-center justify-between text-sm text-gray-700">
+            <div className="mt-auto space-y-3">
+              <div className="flex items-center justify-between text-sm text-base-content/70">
               <div className="flex items-center">
                 <Calendar className="h-4 w-4 mr-1" />
                 {formatDate(project.createdAt)}

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -120,7 +120,7 @@ const Project: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
       {/* Navigation des phases */}
-      <div className="mb-4 card border border-primary/20 py-3 px-8 rounded-xl">
+      <div className="mb-4 card bg-base-100">
         <nav className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-center justify-center gap-x-8">
           {phases.map((phase, index) => {
             const isActive = activeProjectTab === phase.id;
@@ -176,7 +176,7 @@ const Project: React.FC = () => {
       </div>
 
       {/* Contenu de la phase */}
-      <div className="card p-4">
+      <div className="card bg-base-100 p-4">
         {renderPhaseContent()}
       </div>
     </div>

--- a/src/pages/phases/FinalPhase.tsx
+++ b/src/pages/phases/FinalPhase.tsx
@@ -141,7 +141,7 @@ const FinalPhase: React.FC<FinalPhaseProps> = ({ project }) => {
       content: (
         <div className="space-y-8">
           <div className="grid grid-cols-2 gap-8">
-            <div className="bg-card p-6 rounded-lg shadow-sm">
+            <div className="card bg-base-100 p-6 shadow-sm">
               <Checklist
                 items={final.checklist}
                 onItemChange={handleChecklistChange}
@@ -149,7 +149,7 @@ const FinalPhase: React.FC<FinalPhaseProps> = ({ project }) => {
                 onOpenEditor={() => setIsChecklistEditorOpen(true)}
               />
             </div>
-            <div className="bg-card p-6 rounded-lg shadow-sm">
+            <div className="card bg-base-100 p-6 shadow-sm">
               <div className="flex items-center justify-between mb-3">
                 <h3 className="text-lg font-medium text-foreground">Contenu phase approuvé par :</h3>
                 <div className="flex items-center space-x-3">
@@ -297,7 +297,6 @@ const FinalPhase: React.FC<FinalPhaseProps> = ({ project }) => {
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        activeTabColorClass="border-green-600 text-green-800"
       />
 
       <ChecklistEditorModal

--- a/src/pages/phases/InitialPhase.tsx
+++ b/src/pages/phases/InitialPhase.tsx
@@ -97,7 +97,7 @@ const InitialPhase: React.FC<InitialPhaseProps> = ({ project }) => {
       content: (
         <div className="space-y-8">
           <div className="grid grid-cols-2 gap-8">
-            <div className="bg-card p-6 rounded-lg shadow-sm">
+            <div className="card bg-base-100 p-6 shadow-sm">
               <Checklist
                 items={initial.checklist}
                 onItemChange={handleChecklistChange}
@@ -105,7 +105,7 @@ const InitialPhase: React.FC<InitialPhaseProps> = ({ project }) => {
                 onOpenEditor={() => setIsChecklistEditorOpen(true)}
               />
             </div>
-            <div className="bg-card p-6 rounded-lg shadow-sm">
+            <div className="card bg-base-100 p-6 shadow-sm">
               <div className="flex items-center justify-between mb-3">
                 <h3 className="text-lg font-medium text-foreground">Contenu phase approuvé par :</h3>
                 <div className="flex items-center space-x-3">
@@ -268,7 +268,6 @@ const InitialPhase: React.FC<InitialPhaseProps> = ({ project }) => {
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        activeTabColorClass="border-blue-600 text-blue-800"
       />
 
       <ChecklistEditorModal

--- a/src/pages/phases/OptionsPhase.tsx
+++ b/src/pages/phases/OptionsPhase.tsx
@@ -207,7 +207,7 @@ const OptionsPhase: React.FC<OptionsPhaseProps> = ({ project }) => {
       content: (
         <div className="space-y-8">
           <div className="grid grid-cols-2 gap-8">
-            <div className="bg-card p-6 rounded-lg shadow-sm">
+            <div className="card bg-base-100 p-6 shadow-sm">
               <Checklist
                 items={project.data.options.checklist}
                 onItemChange={handleChecklistChange}
@@ -215,7 +215,7 @@ const OptionsPhase: React.FC<OptionsPhaseProps> = ({ project }) => {
                 onOpenEditor={() => setIsChecklistEditorOpen(true)}
               />
             </div>
-            <div className="bg-card p-6 rounded-lg shadow-sm">
+            <div className="card bg-base-100 p-6 shadow-sm">
               <div className="flex items-center justify-between mb-3">
                 <h3 className="text-lg font-medium text-foreground">Contenu phase approuvé par :</h3>
                 <div className="flex items-center space-x-3">
@@ -412,7 +412,7 @@ const OptionsPhase: React.FC<OptionsPhaseProps> = ({ project }) => {
             ))}
           </div>
 
-          <div className="mt-8 p-4 bg-card rounded-lg shadow-sm">
+          <div className="mt-8 card bg-base-100 p-4 shadow-sm">
             <div className="flex items-center justify-between">
               <div>
                 <h3 className="font-medium">Sélection du scénario</h3>
@@ -467,7 +467,6 @@ const OptionsPhase: React.FC<OptionsPhaseProps> = ({ project }) => {
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        activeTabColorClass="border-orange-600 text-orange-800"
       />
 
       {/* Modals */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,32 +1,16 @@
-import colors from 'tailwindcss/colors';
+import daisyui from 'daisyui';
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  darkMode: 'class',
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {
-      colors: {
-        ...colors,
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
-        muted: 'hsl(var(--muted))',
-        card: 'hsl(var(--card))',
-        accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
-        },
-        primary: '#3b82f6',
-        secondary: '#f9fafb',
-        text: '#111827',
-      },
-      width: {
-        '144': '36rem', // 576px (320px * 1.8 = 576px)
-      },
-    },
+    extend: {},
   },
-  plugins: [],
+  plugins: [daisyui],
+  daisyui: {
+    themes: ['light', 'dark'],
+  },
 }


### PR DESCRIPTION
## Summary
- install and configure DaisyUI with light/dark themes
- replace custom components with DaisyUI equivalents and add theme switch
- convert cards and forms to DaisyUI styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build` (fails: TS errors in OptionsPhase.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68ab1fd0d9ac832794d4d26877cc9af9